### PR TITLE
Added additional column to monitor OOM killer score of each process

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -81,6 +81,9 @@ typedef enum ProcessField_ {
    #ifdef HAVE_CGROUP
    CGROUP,
    #endif
+   #ifdef HAVE_OOM
+   OOM,
+   #endif
    IO_PRIORITY,
    LAST_PROCESSFIELD
 } ProcessField;
@@ -177,6 +180,9 @@ typedef struct Process_ {
    #ifdef HAVE_CGROUP
    char* cgroup;
    #endif
+   #ifdef HAVE_OOM
+   unsigned int oom;
+   #endif
 } Process;
 
 }*/
@@ -202,6 +208,9 @@ const char *Process_fieldNames[] = {
 #endif
 #ifdef HAVE_CGROUP
    "CGROUP",
+#endif
+#ifdef HAVE_OOM
+   "OOM",
 #endif
    "IO_PRIORITY",
 "*** report bug! ***"
@@ -229,6 +238,9 @@ const int Process_fieldFlags[] = {
 #ifdef HAVE_CGROUP
    PROCESS_FLAG_CGROUP,
 #endif
+#ifdef HAVE_OOM
+   0,
+#endif
    PROCESS_FLAG_IOPRIO
 };
 
@@ -254,6 +266,9 @@ const char *Process_fieldTitles[] = {
 #ifdef HAVE_CGROUP
    "    CGROUP ",
 #endif
+#ifdef HAVE_OOM
+   "    OOM ",
+#endif
    "IO ",
 "*** report bug! ***"
 };
@@ -276,6 +291,9 @@ void Process_getMaxPid() {
       Process_fieldTitles[TGID] =    "   TGID ";
       Process_fieldTitles[PGRP] =    "   PGRP ";
       Process_fieldTitles[SESSION] = "   SESN ";
+      #ifdef HAVE_OOM
+      Process_fieldTitles[OOM] =     "    OOM ";
+      #endif
       Process_pidFormat = "%7u ";
       Process_tpgidFormat = "%7d ";
    } else {
@@ -285,6 +303,9 @@ void Process_getMaxPid() {
       Process_fieldTitles[TGID] =    " TGID ";
       Process_fieldTitles[PGRP] =    " PGRP ";
       Process_fieldTitles[SESSION] = " SESN ";
+      #ifdef HAVE_OOM
+      Process_fieldTitles[OOM] =     "  OOM ";
+      #endif
       Process_pidFormat = "%5u ";
       Process_tpgidFormat = "%5d ";
    }
@@ -544,6 +565,9 @@ static void Process_writeField(Process* this, RichString* str, ProcessField fiel
    #endif
    #ifdef HAVE_CGROUP
    case CGROUP: snprintf(buffer, n, "%-10s ", this->cgroup); break;
+   #endif
+   #ifdef HAVE_OOM
+   case OOM: snprintf(buffer, n, Process_pidFormat, this->oom); break;
    #endif
    case IO_PRIORITY: {
       int klass = IOPriority_class(this->ioPriority);
@@ -813,6 +837,10 @@ int Process_compare(const void* v1, const void* v2) {
    #ifdef HAVE_CGROUP
    case CGROUP:
       return strcmp(p1->cgroup ? p1->cgroup : "", p2->cgroup ? p2->cgroup : "");
+   #endif
+   #ifdef HAVE_OOM
+   case OOM:
+      return (p1->oom - p2->oom);
    #endif
    case IO_PRIORITY:
       return Process_effectiveIOPriority(p1) - Process_effectiveIOPriority(p2);

--- a/Process.h
+++ b/Process.h
@@ -60,6 +60,9 @@ typedef enum ProcessField_ {
    #ifdef HAVE_CGROUP
    CGROUP,
    #endif
+   #ifdef HAVE_OOM
+   OOM,
+   #endif
    IO_PRIORITY,
    LAST_PROCESSFIELD
 } ProcessField;
@@ -155,6 +158,9 @@ typedef struct Process_ {
    #endif
    #ifdef HAVE_CGROUP
    char* cgroup;
+   #endif
+   #ifdef HAVE_OOM
+   unsigned int oom;
    #endif
 } Process;
 

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -172,6 +172,10 @@ void ProcessList_sort(ProcessList* this);
 
 #endif
 
+#ifdef HAVE_OOM
+
+#endif
+
 
 void ProcessList_scan(ProcessList* this);
 

--- a/configure.ac
+++ b/configure.ac
@@ -145,5 +145,10 @@ then
    AC_CHECK_HEADERS([hwloc.h],[:], [missing_headers="$missing_headers $ac_header"])
 fi
 
+AC_ARG_ENABLE(oom, [AC_HELP_STRING([--enable-oom], [enable OOM score reporting])], ,enable_oom="no")
+if test "x$enable_oom" = xyes; then
+    AC_DEFINE(HAVE_OOM, 1, [Define if OOM score support enabled.])
+fi
+
 AC_CONFIG_FILES([Makefile htop.1])
 AC_OUTPUT

--- a/htop.1.in
+++ b/htop.1.in
@@ -313,6 +313,9 @@ OpenVZ process ID.
 .B VXID
 VServer process ID.
 .TP
+.B OOM
+OOM killer score.
+.TP
 .B All other flags
 Currently unsupported (always displays '-').
 


### PR DESCRIPTION
Hi Hisham,

Thanks so much for _htop_ - I've been using it for a few months and am really grateful for it. Today I ran into a problem that it didn't solve, and thought I'd have a go at adding what I needed.

I have a small VM where the Linux OOM (out-of-memory) killer kills MySQL every few weeks. Looking into this I found I could read the `oom_score` of a process from `/proc/nnnn/oom_score`. I wanted to review the scores of all the running processes before I started changing things, but couldn't find that column within _htop_. I've added a new column called "OOM" to display this information.

I've adjusted the column width in the same way as the PID column but am not sure that was the best thing to do. If you don't like that could you help me improve it?
