### PR TITLE
Read kernel's "MemAvailable" if possible

### DIFF
--- a/MemoryMeter.c
+++ b/MemoryMeter.c
@@ -28,7 +28,8 @@ static void MemoryMeter_setValues(Meter* this, char* buffer, int size) {
    long int usedMem = this->pl->usedMem;
    long int buffersMem = this->pl->buffersMem;
    long int cachedMem = this->pl->cachedMem;
-   usedMem -= buffersMem + cachedMem;
+   long int availMem = this->pl->availMem;
+   if(!availMem) usedMem -= buffersMem + cachedMem;
    this->total = this->pl->totalMem;
    this->values[0] = usedMem;
    this->values[1] = buffersMem;

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -129,6 +129,7 @@ typedef struct ProcessList_ {
    unsigned long long int sharedMem;
    unsigned long long int buffersMem;
    unsigned long long int cachedMem;
+   unsigned long long int availMem;
    unsigned long long int totalSwap;
    unsigned long long int usedSwap;
    unsigned long long int freeSwap;
@@ -906,6 +907,8 @@ void ProcessList_scan(ProcessList* this) {
                sscanf(buffer, "MemFree: %32llu kB", &this->freeMem);
             else if (String_startsWith(buffer, "MemShared:"))
                sscanf(buffer, "MemShared: %32llu kB", &this->sharedMem);
+            else if (String_startsWith(buffer, "MemAvailable:"))
+               sscanf(buffer, "MemAvailable: %32llu kB", &this->availMem);
             break;
          case 'B':
             if (String_startsWith(buffer, "Buffers:"))
@@ -924,8 +927,7 @@ void ProcessList_scan(ProcessList* this) {
          }
       }
    }
-
-   this->usedMem = this->totalMem - this->freeMem;
+   this->usedMem = this->totalMem - (this->availMem ? this->availMem : this->freeMem);
    this->usedSwap = this->totalSwap - swapFree;
    fclose(file);
 


### PR DESCRIPTION
Recent kernel versions support "MemAvailable" in /proc/meminfo
which provides more accurate information on the amount of memory
available. therefore we can now deduce:

usedmem = totalmem - MemAvailable;
