### PR TITLE
Omit non-printable characters with widechar curses

### DIFF
--- a/RichString.c
+++ b/RichString.c
@@ -94,7 +94,7 @@ static inline void RichString_writeFrom(RichString* this, int attrs, const char*
    RichString_setLen(this, newLen);
    memset(&this->chptr[from], 0, sizeof(CharType) * (newLen - from));
    for (int i = from, j = 0; i < newLen; i++, j++) {
-      this->chptr[i].chars[0] = data[j];
+      this->chptr[i].chars[0] = (iswprint(data[j]) ? data[j] : '?');
       this->chptr[i].attr = attrs;
    }
    this->chptr[newLen].chars[0] = 0;


### PR DESCRIPTION
This patch replaces nonprintable characters with '?' (questionmark), just like ps and htop without widechar curses handle this.

This prevents possible spoofing attacks using control characters to misplace output (in my tests, using a nonprintable character made the cursor move one character to the left, thus I was able to override other colmuns contents using my process’ name).