### PR TITLE
Fix basename highlighting for (linux) kernel threads with complex names.

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -444,14 +444,22 @@ static inline void Process_writeCommand(Process* this, int attr, int baseattr, R
       int finish = RichString_size(str) - 1;
       if (this->basenameOffset != -1)
          finish = (start + this->basenameOffset) - 1;
-      int colon = RichString_findChar(str, ':', start);
-      if (colon != -1 && colon < finish) {
-         finish = colon;
+
+      if (Process_isKernelThread(this)) {
+         int slash = RichString_findChar(str, '/', start);
+         if (slash != -1 && slash < finish) {
+            finish = slash;
+         }
       } else {
-         for (int i = finish - start; i >= 0; i--) {
-            if (this->comm[i] == '/') {
-               start += i+1;
-               break;
+         int colon = RichString_findChar(str, ':', start);
+         if (colon != -1 && colon < finish) {
+            finish = colon;
+         } else {
+            for (int i = finish - start; i >= 0; i--) {
+               if (this->comm[i] == '/') {
+                  start += i+1;
+                  break;
+               }
             }
          }
       }


### PR DESCRIPTION
"kworker/0:0H", "migration/2", .., and friends are currently having their basename highlighted in a wrong fashion (highlighter looks for the slash backwards).

IMO the true basename for a kernel thread is what comes before the slash; this slightly pedantic patch takes care of that. Not tested in any platform other than plain GNU/Linux -- I hope I'm not breaking others.