### PR TITLE
Fix issue #77 CGROUP output malformed

### DIFF
--- a/ProcessList.c
+++ b/ProcessList.c
@@ -621,18 +621,19 @@ static void ProcessList_readCGroupFile(Process* process, const char* dirname, co
       return;
    }
    char buffer[256];
-   char *ok = fgets(buffer, 255, file);
-   if (ok) {
-      char* trimmed = String_trim(buffer);
-      int nFields;
-      char** fields = String_split(trimmed, ':', &nFields);
-      free(trimmed);
-      if (nFields >= 3) {
-         process->cgroup = strndup(fields[2] + 1, 10);
-      } else {
-         process->cgroup = strdup("");
+   while (fgets(buffer, 255, file)) {
+      if (!String_endsWith(buffer, "/")) {
+         char* trimmed = String_trim(buffer);
+         int nFields;
+         char** fields = String_split(trimmed, ':', &nFields);
+         free(trimmed);
+         if (nFields >= 3) {
+            process->cgroup = strndup(fields[2] + 1, 10);
+         } else {
+            process->cgroup = strdup("");
+         }
+         String_freeArray(fields);
       }
-      String_freeArray(fields);
    }
    fclose(file);
 }

--- a/String.c
+++ b/String.c
@@ -127,3 +127,13 @@ char* String_getToken(const char* line, const unsigned short int numMatch) {
    match[foundCount] = '\0';
    return((char*)strdup(match));
 }
+
+inline int String_endsWith(const char* s, const char* match) {
+   if (s == NULL || match == NULL)
+      return 0;
+   size_t lens = strlen(s);
+   size_t lenmatch = strlen(match);
+   if (lenmatch > lens)
+      return 0;
+   return strncmp(s + lens - lenmatch, match, lenmatch) == 0;
+}

--- a/String.h
+++ b/String.h
@@ -24,4 +24,6 @@ void String_freeArray(char** s);
 
 char* String_getToken(const char* line, const unsigned short int numMatch);
 
+extern int String_endsWith(const char* s, const char* match);
+
 #endif


### PR DESCRIPTION
Same strategy as procps-ng, reading every line and ignoring the ones with empty root entries.
It has only been tested on Gentoo/OpenRC/3.14.14-gentoo with cgroups enabled but should be universal.
