### PR TITLE
Interpret command line PIDs as PIDs, not TIDs

### DIFF
--- a/ProcessList.c
+++ b/ProcessList.c
@@ -1074,7 +1074,7 @@ void ProcessList_rebuildPanel(ProcessList* this, bool flags, int following, bool
       if ( (!p->show)
          || (userOnly && (p->st_uid != userId))
          || (incFilter && !(String_contains_i(p->comm, incFilter)))
-         || (this->pidWhiteList && !Hashtable_get(this->pidWhiteList, p->pid)) )
+         || (this->pidWhiteList && !Hashtable_get(this->pidWhiteList, p->tgid)) )
          hidden = true;
 
       if (!hidden) {


### PR DESCRIPTION
The `-p` command line option takes TIDs, but arguably PIDs would be more useful. Here are some reasons why:

 * Personally, I often want to look at a particular process, and much less often a particular thread. 
 * It can be confusing to specify a PID and see only the main thread, especially if the user is unaware there may exist more threads.
 * Threads may come and go, so a list taken by the user before starting htop may not be accurate later.