### PR TITLE
Automatically follow on process accross tree view / sort order changes

### DIFF
--- a/htop.1.in
+++ b/htop.1.in
@@ -140,8 +140,8 @@ Sort by time (top compatibility key).
 "Follow" process: if the sort order causes the currently selected process
 to move in the list, make the selection bar follow it. This is useful for
 monitoring a process: this way, you can keep a process always visible on
-screen. When a movement key is used, "follow" loses effect.  When toggling
-tree view, follow is automatically enabled.
+screen. The current process is always followed on any change to sort order,
+or when toggling tree view. When a movement key is used, "follow" loses effect.
 .TP
 .B K
 Hide kernel threads: prevent the threads belonging the kernel to be

--- a/htop.1.in
+++ b/htop.1.in
@@ -140,7 +140,8 @@ Sort by time (top compatibility key).
 "Follow" process: if the sort order causes the currently selected process
 to move in the list, make the selection bar follow it. This is useful for
 monitoring a process: this way, you can keep a process always visible on
-screen. When a movement key is used, "follow" loses effect.
+screen. When a movement key is used, "follow" loses effect.  When toggling
+tree view, follow is automatically enabled.
 .TP
 .B K
 Hide kernel threads: prevent the threads belonging the kernel to be

--- a/htop.c
+++ b/htop.c
@@ -604,6 +604,7 @@ int main(int argc, char** argv) {
                      setSortKey(pl, defaultBar, field, panel, settings);
                   }
                   refreshTimeout = 0;
+                  follow = true;
                   continue;
                } else if (mevent.y >= panel->y + 1 && mevent.y < LINES - 1) {
                   Panel_setSelected(panel, mevent.y - panel->y + panel->scrollV - 1);
@@ -650,6 +651,8 @@ int main(int argc, char** argv) {
          acc = 0;
       }
 
+      // The difference between break vs continue out of this switch
+      // is that break also resets follow = false.
       switch (ch) {
       case KEY_RESIZE:
          Panel_resize(panel, COLS, LINES-headerHeight-1);
@@ -659,13 +662,15 @@ int main(int argc, char** argv) {
       {
          refreshTimeout = 0;
          setSortKey(pl, defaultBar, PERCENT_MEM, panel, settings);
-         break;
+         follow = true;
+         continue;
       }
       case 'T':
       {
          refreshTimeout = 0;
          setSortKey(pl, defaultBar, TIME, panel, settings);
-         break;
+         follow = true;
+         continue;
       }
       case 'c':
       {
@@ -687,7 +692,8 @@ int main(int argc, char** argv) {
       {
          refreshTimeout = 0;
          setSortKey(pl, defaultBar, PERCENT_CPU, panel, settings);
-         break;
+         follow = true;
+         continue;
       }
       case KEY_F(1):
       case 'h':
@@ -847,7 +853,8 @@ int main(int argc, char** argv) {
       {
          sortBy(panel, pl, settings, headerHeight, defaultBar, header);
          refreshTimeout = 0;
-         break;
+         follow = true;
+         continue;
       }
       case KEY_F(18):
       case KEY_F(6):
@@ -887,7 +894,8 @@ int main(int argc, char** argv) {
          refreshTimeout = 0;
          settings->changed = true;
          ProcessList_invertSortOrder(pl);
-         break;
+         follow = true;
+         continue;
       }
       case KEY_F(8):
       case '[':

--- a/htop.c
+++ b/htop.c
@@ -920,8 +920,8 @@ int main(int argc, char** argv) {
          ProcessList_printHeader(pl, Panel_getHeader(panel));
          ProcessList_expandTree(pl);
          settings->changed = true;
-         if (following != -1) continue;
-         break;
+         follow = true;
+         continue;
       case 'H':
          doRecalculate = true;
          refreshTimeout = 0;


### PR DESCRIPTION
The first commit closes #51.  I think that's a clear win - it's useful to follow a busy process to/from tree view to find its children/parent, and I can't think of any use for staying at the same screen position.
It also keeps following after the switch.  Let me know if you prefer to restore follow=false afterwards, but I think that'd be worse - e.g. going from tree view to CPU sort (which jumps around a lot), you'd follow the current process only to lose it a second later.

The second commit also enables following on any sort order change (if I covered all code paths that do that...).
I'm not sure that's always desired.  The main use case for _not_ following is staying at the top of the screen to look at worse offenders for each resource (which is certainly common use of top!).  But if following is default, one can always go to top of the list with `Home`, whereas if you have to press `F` before switching but forgot, there is no easy way to undo losing the selected process.
The most dubious case is following on inverting sort order (`I`) — the likely reason to press it is wanting to look at opposite processes, not same process on other end of screen... 

Finally, if you like both changes, the `continue` vs `break` structure (the latter implying `follow = false;`) is IMHO getting messy.
It made more sense when most cases that did change it were to false, but now it's more symmetric. 
I'd refactor to explicitly assigning false/true in every case that changes it — let me know what you prefer.

P.S. Thanks for htop, it's the first thing I install on every machine I use!
