### PR TITLE
[PATCH] New setting: "Show program path"

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -211,6 +211,11 @@ static Htop_Reaction actionToggleUserlandThreads(State* st) {
    return HTOP_RECALCULATE | HTOP_SAVE_SETTINGS;
 }
 
+static Htop_Reaction actionToggleProgramPath(State* st) {
+   st->settings->showProgramPath = !st->settings->showProgramPath;
+   return HTOP_REFRESH | HTOP_SAVE_SETTINGS;
+}
+
 static Htop_Reaction actionToggleTreeView(State* st) {
    st->settings->treeView = !st->settings->treeView;
    if (st->settings->treeView) st->settings->direction = 1;
@@ -501,6 +506,7 @@ void Action_setBindings(Htop_Action* keys) {
    keys['P'] = actionSortByCPU;
    keys['H'] = actionToggleUserlandThreads;
    keys['K'] = actionToggleKernelThreads;
+   keys['p'] = actionToggleProgramPath;
    keys['t'] = actionToggleTreeView;
    keys[KEY_F(5)] = actionToggleTreeView;
    keys[KEY_F(4)] = actionIncFilter;

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -87,6 +87,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_new(strdup("Hide userland threads"), &(settings->hideUserlandThreads), false));
    Panel_add(super, (Object*) CheckItem_new(strdup("Display threads in a different color"), &(settings->highlightThreads), false));
    Panel_add(super, (Object*) CheckItem_new(strdup("Show custom thread names"), &(settings->showThreadNames), false));
+   Panel_add(super, (Object*) CheckItem_new(strdup("Show program path"), &(settings->showProgramPath), true));
    Panel_add(super, (Object*) CheckItem_new(strdup("Highlight program \"basename\""), &(settings->highlightBaseName), false));
    Panel_add(super, (Object*) CheckItem_new(strdup("Highlight large numbers in memory counters"), &(settings->highlightMegabytes), false));
    Panel_add(super, (Object*) CheckItem_new(strdup("Leave a margin around header"), &(settings->headerMargin), false));

--- a/Settings.c
+++ b/Settings.c
@@ -45,6 +45,7 @@ typedef struct Settings_ {
    bool countCPUsFromZero;
    bool detailedCPUTime;
    bool treeView;
+   bool showProgramPath;
    bool hideThreads;
    bool shadowOtherUsers;
    bool showThreadNames;
@@ -185,6 +186,8 @@ static bool Settings_read(Settings* this, const char* fileName, int cpuCount) {
          this->shadowOtherUsers = atoi(option[1]);
       } else if (String_eq(option[0], "show_thread_names")) {
          this->showThreadNames = atoi(option[1]);
+      } else if (String_eq(option[0], "show_program_path")) {
+         this->showProgramPath = atoi(option[1]);
       } else if (String_eq(option[0], "highlight_base_name")) {
          this->highlightBaseName = atoi(option[1]);
       } else if (String_eq(option[0], "highlight_megabytes")) {
@@ -271,6 +274,7 @@ bool Settings_write(Settings* this) {
    fprintf(fd, "hide_userland_threads=%d\n", (int) this->hideUserlandThreads);
    fprintf(fd, "shadow_other_users=%d\n", (int) this->shadowOtherUsers);
    fprintf(fd, "show_thread_names=%d\n", (int) this->showThreadNames);
+   fprintf(fd, "show_program_path=%d\n", (int) this->showProgramPath);
    fprintf(fd, "highlight_base_name=%d\n", (int) this->highlightBaseName);
    fprintf(fd, "highlight_megabytes=%d\n", (int) this->highlightMegabytes);
    fprintf(fd, "highlight_threads=%d\n", (int) this->highlightThreads);

--- a/Settings.h
+++ b/Settings.h
@@ -36,6 +36,7 @@ typedef struct Settings_ {
    bool countCPUsFromZero;
    bool detailedCPUTime;
    bool treeView;
+   bool showProgramPath;
    bool hideThreads;
    bool shadowOtherUsers;
    bool showThreadNames;

--- a/htop.1.in
+++ b/htop.1.in
@@ -151,6 +151,9 @@ Hide user threads: on systems that represent them differently than ordinary
 processes (such as recent NPTL-based systems), this can hide threads from
 userspace processes in the process list. (This is a toggle key.)
 .TP
+.B p
+Show full paths to running programs, where applicable. (This is a toggle key.)
+.TP
 .B Ctrl-L
 Refresh: redraw screen and recalculate values.
 .TP


### PR DESCRIPTION
Add a setting to hide all but the last component from the programme
path, leaving only the "basename". Makes htop more usable on smaller
screens, or systems with longer than average paths. Off by default.

"Highlight program basename" will still be respected, to further
visually separate process names from their arguments.

Tested on Linux, but doesn't touch anything OS-specific.