### PR TITLE
Add ZFS cache awareness to memory meters.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -138,6 +138,11 @@ else
             [AC_CHECK_HEADERS([ncurses.h],[:],[missing_headers="$missing_headers $ac_header"])])])])
 fi
 
+AC_ARG_ENABLE(zfs_cache_awareness, [AC_HELP_STRING([--enable-zfs-cache-awareness],[enable ZFS cache awareness for memory usage])], enable_zfs_cache_awareness="yes",enable_zfs_cache_awareness="no")
+if test "x$enable_zfs_cache_awareness" = xyes; then
+    AC_DEFINE(HAVE_ZFS, 1, [Define if we want the memory meter to be aware of the ZFS cache])
+fi
+
 AC_ARG_ENABLE(native_affinity, [AC_HELP_STRING([--enable-native-affinity], [enable native sched_setaffinity and sched_getaffinity for affinity support, disables hwloc])], ,enable_native_affinity="yes")
 if test "x$enable_native_affinity" = xyes -a "x$cross_compiling" = xno; then
    AC_MSG_CHECKING([for usable sched_setaffinity])

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -43,6 +43,9 @@ in the source distribution for its full text.
 #define PROCMEMINFOFILE PROCDIR "/meminfo"
 #endif
 
+#ifndef ZFSINFOFILE
+#define ZFSINFOFILE "/proc/spl/kstat/zfs/arcstats"
+#endif
 }*/
    
 ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList) {
@@ -611,6 +614,31 @@ static inline void LinuxProcessList_scanMemoryInfo(ProcessList* this) {
          break;
       }
    }
+
+#ifdef HAVE_ZFS
+   FILE* zfsFile = fopen(ZFSINFOFILE,"r");
+   if( zfsFile != NULL)
+   {
+      unsigned long long int zfsMem = 0;
+      while(fgets(buffer,128,zfsFile) && zfsMem == 0)
+      {
+         switch(buffer[0])
+         {
+            case 's':
+               if(String_startsWith(buffer, "size"))
+                  sscanf(buffer,"size %*i %32llu",&zfsMem);
+                  zfsMem /= 1024;
+                  break;
+            default:
+               break;
+         }
+      }
+      this->cachedMem += zfsMem;
+      fclose(zfsFile);
+   }
+#endif
+
+
 
    this->usedMem = this->totalMem - this->freeMem;
    this->usedSwap = this->totalSwap - swapFree;

--- a/linux/LinuxProcessList.h
+++ b/linux/LinuxProcessList.h
@@ -24,6 +24,9 @@ in the source distribution for its full text.
 #define PROCMEMINFOFILE PROCDIR "/meminfo"
 #endif
 
+#ifndef ZFSINFOFILE
+#define ZFSINFOFILE "/proc/spl/kstat/zfs/arcstats"
+#endif
    
 ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList);
 


### PR DESCRIPTION
Enable with --enable-zfs-cache-awareness

(Only tested with ZFS on linux)
