### PR TITLE
Fixed tree drawing for hidden elements

### DIFF
--- a/ProcessList.c
+++ b/ProcessList.c
@@ -286,7 +286,14 @@ static void ProcessList_buildTree(ProcessList* this, pid_t pid, int level, int i
          Vector_add(children, process);
       }
    }
+   
    int size = Vector_size(children);
+   
+   int lastShown = -1;
+   for (int i = 0; i < size; i++)
+      if (((Process*) Vector_get(children, i))->show)
+         lastShown = i;
+   
    for (int i = 0; i < size; i++) {
       Process* process = (Process*) (Vector_get(children, i));
       if (!show)
@@ -298,8 +305,8 @@ static void ProcessList_buildTree(ProcessList* this, pid_t pid, int level, int i
          Vector_insert(this->processes2, 0, process);
       assert(this->processes2->items == s+1); (void)s;
       int nextIndent = indent | (1 << level);
-      ProcessList_buildTree(this, process->pid, level+1, (i < size - 1) ? nextIndent : indent, direction, show ? process->showChildren : false);
-      if (i == size - 1)
+      ProcessList_buildTree(this, process->pid, level+1, (i < lastShown) ? nextIndent : indent, direction, show ? process->showChildren : false);
+      if (i == lastShown)
          process->indent = -nextIndent;
       else
          process->indent = nextIndent;


### PR DESCRIPTION
The tree view has to treat the last element differently ('├' vs '└'). Previously, it would simply pick the last element in the children list, leading to incorrect display if that one happened to be hidden (e.g. because of the "hide userland threads" config option).