### PR TITLE
fix compiler warnings

### DIFF
--- a/TraceScreen.c
+++ b/TraceScreen.c
@@ -93,7 +93,8 @@ void TraceScreen_run(TraceScreen* this) {
          execlp("strace", "strace", "-p", buffer, NULL);
       }
       const char* message = "Could not execute 'strace'. Please make sure it is available in your $PATH.";
-      write(fdpair[1], message, strlen(message));
+      ssize_t written = write(fdpair[1], message, strlen(message));
+      (void) written;
       exit(1);
    }
    fcntl(fdpair[0], F_SETFL, O_NONBLOCK);

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -94,7 +94,8 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, ui
    int cpus = -1;
    do {
       cpus++;
-      fgets(buffer, 255, file);
+      char * s = fgets(buffer, 255, file);
+      (void) s;
    } while (String_startsWith(buffer, "cpu"));
    fclose(file);
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -110,7 +110,8 @@ int Platform_getMaxPid() {
    FILE* file = fopen(PROCDIR "/sys/kernel/pid_max", "r");
    if (!file) return -1;
    int maxPid = 4194303;
-   (void) fscanf(file, "%32d", &maxPid);
+   int match = fscanf(file, "%32d", &maxPid);
+   (void) match;
    fclose(file);
    return maxPid;
 }


### PR DESCRIPTION
gcc gives warnings like this:

warning: ignoring return value of ‘fscanf’, declared with attribute
warn_unused_result

Assign value to a variable, cast to (void) to discard it.