### PR TITLE
Fix several FreeBSD compilation errors

### DIFF
--- a/freebsd/FreeBSDProcess.h
+++ b/freebsd/FreeBSDProcess.h
@@ -28,6 +28,8 @@ typedef struct FreeBSDProcess_ {
 #endif
 
 
+extern ProcessClass FreeBSDProcess_class;
+
 extern ProcessFieldData Process_fields[];
 
 extern char* Process_pidFormat;
@@ -39,9 +41,9 @@ FreeBSDProcess* FreeBSDProcess_new(Settings* settings);
 
 void Process_delete(Object* cast);
 
-void Process_writeField(Process* this, RichString* str, ProcessField field);
+void FreeBSDProcess_writeField(Process* this, RichString* str, ProcessField field);
 
-long Process_compare(const void* v1, const void* v2);
+long FreeBSDProcess_compare(const void* v1, const void* v2);
 
 bool Process_isThread(Process* this);
 

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -146,7 +146,7 @@ void ProcessList_goThroughEntries(ProcessList* this) {
       struct kinfo_proc* kproc = &kprocs[i];
       
       bool preExisting = false;
-      Process* proc = ProcessList_getProcess(this, kproc->ki_pid, &preExisting, (Process_new_fn) FreeBSDProcess_new);
+      Process* proc = ProcessList_getProcess(this, kproc->ki_pid, &preExisting, (Process_New) FreeBSDProcess_new);
       FreeBSDProcess* fp = (FreeBSDProcess*) proc;
 
       proc->show = ! ((hideKernelThreads && Process_isKernelThread(proc)) || (hideUserlandThreads && Process_isUserlandThread(proc)));


### PR DESCRIPTION
Several functions and structures had their name changed in previous commits and cause compilation errors.