### PR TITLE
Change all displayed memory size specifiers to use GNU Coreutils style size specifiers

### DIFF
--- a/MemoryMeter.c
+++ b/MemoryMeter.c
@@ -26,7 +26,7 @@ int MemoryMeter_attributes[] = {
 
 static void MemoryMeter_setValues(Meter* this, char* buffer, int size) {
    Platform_setMemoryValues(this);
-   snprintf(buffer, size, "%ld/%ldMB", (long int) this->values[0] / 1024, (long int) this->total / 1024);
+   snprintf(buffer, size, "%ld/%ldM", (long int) this->values[0] / 1024, (long int) this->total / 1024);
 }
 
 static void MemoryMeter_display(Object* cast, RichString* out) {

--- a/SwapMeter.c
+++ b/SwapMeter.c
@@ -35,7 +35,7 @@ static void SwapMeter_humanNumber(char* buffer, const long int* value) {
 
 static void SwapMeter_setValues(Meter* this, char* buffer, int len) {
    Platform_setSwapValues(this);
-   snprintf(buffer, len, "%ld/%ldMB", (long int) this->values[0] / MEGABYTE, (long int) this->total / MEGABYTE);
+   snprintf(buffer, len, "%ld/%ldM", (long int) this->values[0] / MEGABYTE, (long int) this->total / MEGABYTE);
 }
 
 static void SwapMeter_display(Object* cast, RichString* out) {

--- a/htop.1.in
+++ b/htop.1.in
@@ -353,6 +353,15 @@ You may override the location of the configuration file using the $HTOPRC
 environment variable (so you can have multiple configurations for different
 machines that share the same home directory, for example).
 
+.SH "MEMORY SIZES"
+.LP
+Memory sizes in htop are displayed as they are in tools from the GNU Coreutils
+(when ran with the --human-readable option). This means that sizes are printed
+in powers of 1024. (e.g., 1023M = 1072693248 Bytes)
+.LP
+The decision to use this convention was made in order to conserve screen space
+and make memory size representations consistent throughout htop.
+
 .SH "SEE ALSO"
 proc(5), top(1), free(1), ps(1), uptime(1)
 


### PR DESCRIPTION
These patches should standardise the memory size specifiers used within htop.
It only addresses visual inconsistencies, however, there are still a lot of instances in the htop source where a mix of JEDEC standard and IEC standard is used.