### PR TITLE
LoadAverage-bar view 1, 5 and 15 mins separated

### DIFF
--- a/LoadAverageMeter.c
+++ b/LoadAverageMeter.c
@@ -25,6 +25,12 @@ static void LoadAverageMeter_setValues(Meter* this, char* buffer, int size) {
    snprintf(buffer, size, "%.2f/%.2f/%.2f", this->values[2], this->values[1], this->values[0]);
 }
 
+static void LoadAverageMeter_init(Meter* this) {
+   int cpus = this->pl->cpuCount;
+// Load agerage should be lower than #CPUs 3 <= 1,5,15mins
+   this->total = 3*cpus;
+}
+
 static void LoadAverageMeter_display(Object* cast, RichString* out) {
    Meter* this = (Meter*)cast;
    char buffer[20];
@@ -36,12 +42,19 @@ static void LoadAverageMeter_display(Object* cast, RichString* out) {
    RichString_append(out, CRT_colors[LOAD_AVERAGE_ONE], buffer);
 }
 
+static void LoadMeter_init(Meter* this) {
+   int cpus = this->pl->cpuCount;
+// Load agerage should be lower than #CPUs
+   this->total = cpus;
+}
+
 static void LoadMeter_setValues(Meter* this, char* buffer, int size) {
    double five, fifteen;
    Platform_getLoadAverage(&this->values[0], &five, &fifteen);
-   if (this->values[0] > this->total) {
-      this->total = this->values[0];
-   }
+// no rescale
+//   if (this->values[0] > this->total) {
+//      this->total = this->values[0];
+//   }
    snprintf(buffer, size, "%.2f", this->values[0]);
 }
 
@@ -66,7 +79,8 @@ MeterClass LoadAverageMeter_class = {
    .name = "LoadAverage",
    .uiName = "Load average",
    .description = "Load averages: 15 minutes, 5 minutes, 1 minute",
-   .caption = "Load average: "
+   .caption = "Load average: ",
+   .init = LoadAverageMeter_init
 };
 
 MeterClass LoadMeter_class = {
@@ -82,5 +96,6 @@ MeterClass LoadMeter_class = {
    .name = "Load",
    .uiName = "Load",
    .description = "Load: average of ready processes in the last minute",
-   .caption = "Load: "
+   .caption = "Load: ",
+   .init = LoadMeter_init
 };

--- a/LoadAverageMeter.c
+++ b/LoadAverageMeter.c
@@ -10,6 +10,8 @@ in the source distribution for its full text.
 #include "CRT.h"
 #include "Platform.h"
 
+#include <stdlib.h>
+
 /*{
 #include "Meter.h"
 }*/
@@ -25,10 +27,53 @@ static void LoadAverageMeter_setValues(Meter* this, char* buffer, int size) {
    snprintf(buffer, size, "%.2f/%.2f/%.2f", this->values[2], this->values[1], this->values[0]);
 }
 
+static void LoadAverage3Meter_setValues(Meter* this, char* buffer, int size) {
+   double tmp;
+   switch(this->param){
+      case 2:
+        Platform_getLoadAverage(&tmp,&tmp,&this->values[0]);
+        break;
+      case 1:
+        Platform_getLoadAverage(&tmp,&this->values[1],&tmp);
+        break;
+      case 0:
+        Platform_getLoadAverage(&this->values[2],&tmp,&tmp);
+        break;
+   }
+   snprintf(buffer, size, "%.2f", this->values[2-this->param]);
+}
+
 static void LoadAverageMeter_init(Meter* this) {
    int cpus = this->pl->cpuCount;
 // Load agerage should be lower than #CPUs 3 <= 1,5,15mins
    this->total = 3*cpus;
+}
+
+static void LoadAverage3Meter_init(Meter* this) {
+   if (!this->drawData)
+      this->drawData = calloc(3, sizeof(Meter*));
+   Meter** meters = (Meter**) this->drawData;
+   for (int i = 0; i < 3; i++) {
+      if (!meters[i])
+         meters[i] = Meter_new(this->pl, i, (MeterClass*) Class(LoadAverage1Meter));
+      Meter_init(meters[i]);
+      if(i>0) Meter_setCaption(meters[i],"");
+   }
+}
+
+static void LoadAverage1Meter_init(Meter* this) {
+   int cpus = this->pl->cpuCount;
+   this->total = cpus;
+}
+
+static void LoadAverage3Meter_draw(Meter* this, int x, int y, int w) {
+   Meter** meters = (Meter**) this->drawData;
+// 4 = captionLen + 1, form Metter.c
+   int wid = (w-4)/3;
+   int corr = (w-4)%3;
+   meters[0]->draw(meters[0], x, y,wid+4);
+   meters[1]->draw(meters[1], x+1*wid, y,wid+4+(corr==2?1:0));
+   meters[2]->draw(meters[2], x+2*wid+(corr==2?1:0), y,wid+4+(corr>=1?1:0));
 }
 
 static void LoadAverageMeter_display(Object* cast, RichString* out) {
@@ -74,13 +119,49 @@ MeterClass LoadAverageMeter_class = {
    .setValues = LoadAverageMeter_setValues, 
    .defaultMode = TEXT_METERMODE,
    .maxItems = 3,
-   .total = 100.0,
+   .total = 3.0,
    .attributes = LoadAverageMeter_attributes,
    .name = "LoadAverage",
    .uiName = "Load average",
    .description = "Load averages: 15 minutes, 5 minutes, 1 minute",
    .caption = "Load average: ",
    .init = LoadAverageMeter_init
+};
+
+MeterClass LoadAverage3Meter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete,
+      .display = LoadAverageMeter_display,
+   },
+   .defaultMode = CUSTOM_METERMODE,
+   .maxItems = 3,
+   .total = 3.0,
+   .attributes = LoadAverageMeter_attributes,
+   .name = "LoadAverage3",
+   .uiName = "Load average 3c",
+   .description = "Load averages (3 col): 15 minutes, 5 minutes, 1 minute",
+   .caption = "Load average: ",
+   .draw = LoadAverage3Meter_draw,
+   .init = LoadAverage3Meter_init
+};
+
+MeterClass LoadAverage1Meter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete,
+      .display = LoadAverageMeter_display,
+   },
+   .setValues = LoadAverage3Meter_setValues, 
+   .defaultMode = BAR_METERMODE,
+   .maxItems = 3,
+   .total = 1.0,
+   .attributes = LoadAverageMeter_attributes,
+   .name = "LoadAverage",
+   .uiName = "Load average",
+   .description = "Load averages: 15 minutes, 5 minutes, 1 minute",
+   .caption = "Load average: ",
+   .init = LoadAverage1Meter_init
 };
 
 MeterClass LoadMeter_class = {
@@ -91,7 +172,7 @@ MeterClass LoadMeter_class = {
    },
    .setValues = LoadMeter_setValues, 
    .defaultMode = TEXT_METERMODE,
-   .total = 100.0,
+   .total = 1.0,
    .attributes = LoadMeter_attributes,
    .name = "Load",
    .uiName = "Load",

--- a/LoadAverageMeter.h
+++ b/LoadAverageMeter.h
@@ -17,6 +17,10 @@ extern int LoadMeter_attributes[];
 
 extern MeterClass LoadAverageMeter_class;
 
+extern MeterClass LoadAverage3Meter_class;
+
+extern MeterClass LoadAverage1Meter_class;
+
 extern MeterClass LoadMeter_class;
 
 #endif

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -44,6 +44,7 @@ MeterClass* Platform_meterTypes[] = {
    &CPUMeter_class,
    &ClockMeter_class,
    &LoadAverageMeter_class,
+   &LoadAverage3Meter_class,
    &LoadMeter_class,
    &MemoryMeter_class,
    &SwapMeter_class,

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -65,6 +65,7 @@ MeterClass* Platform_meterTypes[] = {
    &CPUMeter_class,
    &ClockMeter_class,
    &LoadAverageMeter_class,
+   &LoadAverage3Meter_class,
    &LoadMeter_class,
    &MemoryMeter_class,
    &SwapMeter_class,

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -29,6 +29,7 @@ MeterClass* Platform_meterTypes[] = {
    &CPUMeter_class,
    &ClockMeter_class,
    &LoadAverageMeter_class,
+   &LoadAverage3Meter_class,
    &LoadMeter_class,
    &MemoryMeter_class,
    &SwapMeter_class,


### PR DESCRIPTION
Hi, I add new bar-view for the LoadAverage; there are three separated bars at one row for 1, 5 and 15 minutes. See to the second row in Figure.

![luuuucky-htop-2](https://cloud.githubusercontent.com/assets/1250507/8321048/5a160468-1a22-11e5-9b7f-7113dab9d7ee.png)

It depends on my previous pull-request #213 (rescaling "total" of load average).

Lukas

PS: I fixed one misc.
