### PR TITLE
fix calloc() calls

### DIFF
--- a/Header.c
+++ b/Header.c
@@ -89,7 +89,7 @@ void Header_writeBackToSettings(const Header* this) {
       
       for (int i = 0; i < len; i++) {
          Meter* meter = (Meter*) Vector_get(vec, i);
-         char* name = calloc(64, sizeof(char*));
+         char* name = calloc(64, sizeof(char));
          if (meter->param) {
             snprintf(name, 63, "%s(%d)", As_Meter(meter)->name, meter->param);
          } else {

--- a/Panel.c
+++ b/Panel.c
@@ -455,7 +455,7 @@ bool Panel_onKey(Panel* this, int key) {
 HandlerResult Panel_selectByTyping(Panel* this, int ch) {
    int size = Panel_size(this);
    if (!this->eventHandlerState)
-      this->eventHandlerState = calloc(100, 1);
+      this->eventHandlerState = calloc(100, sizeof(char));
    char* buffer = this->eventHandlerState;
 
    if (ch < 255 && isalnum(ch)) {

--- a/darwin/DarwinProcess.c
+++ b/darwin/DarwinProcess.c
@@ -39,7 +39,7 @@ ProcessClass DarwinProcess_class = {
 };
 
 DarwinProcess* DarwinProcess_new(Settings* settings) {
-   DarwinProcess* this = calloc(sizeof(DarwinProcess), 1);
+   DarwinProcess* this = calloc(1, sizeof(DarwinProcess));
    Object_setClass(this, Class(DarwinProcess));
    Process_init(&this->super, settings);
 

--- a/freebsd/FreeBSDProcess.c
+++ b/freebsd/FreeBSDProcess.c
@@ -86,7 +86,7 @@ ProcessPidColumn Process_pidColumns[] = {
 };
 
 FreeBSDProcess* FreeBSDProcess_new(Settings* settings) {
-   FreeBSDProcess* this = calloc(sizeof(FreeBSDProcess), 1);
+   FreeBSDProcess* this = calloc(1, sizeof(FreeBSDProcess));
    Object_setClass(this, Class(FreeBSDProcess));
    Process_init(&this->super, settings);
    return this;

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -242,7 +242,7 @@ ProcessClass LinuxProcess_class = {
 };
 
 LinuxProcess* LinuxProcess_new(Settings* settings) {
-   LinuxProcess* this = calloc(sizeof(LinuxProcess), 1);
+   LinuxProcess* this = calloc(1, sizeof(LinuxProcess));
    Object_setClass(this, Class(LinuxProcess));
    Process_init(&this->super, settings);
    return this;

--- a/unsupported/UnsupportedProcess.c
+++ b/unsupported/UnsupportedProcess.c
@@ -17,7 +17,7 @@ in the source distribution for its full text.
 }*/
 
 Process* UnsupportedProcess_new(Settings* settings) {
-   Process* this = calloc(sizeof(Process), 1);
+   Process* this = calloc(1, sizeof(Process));
    Object_setClass(this, Class(Process));
    Process_init(this, settings);
    return this;


### PR DESCRIPTION
* size_t nmemb (number of elements) first, then size_t size
* do not assume char is size 1 but use sizeof()
* allocate for char, not pointer to char (found by Michael McConville,
  fixes #261)