### PR TITLE
Darwin fixes - duplicate & conflicting decls

### DIFF
--- a/Process.h
+++ b/Process.h
@@ -158,8 +158,6 @@ typedef struct ProcessClass_ {
 #define ONE_DECIMAL_M (ONE_DECIMAL_K * ONE_DECIMAL_K)
 #define ONE_DECIMAL_G (ONE_DECIMAL_M * ONE_DECIMAL_K)
 
-extern char Process_pidFormat[20];
-
 void Process_setupColumnWidths();
 
 void Process_humanNumber(RichString* str, unsigned long number, bool coloring);

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -81,7 +81,6 @@ void Platform_setBindings(Htop_Action* keys) {
 }
 
 int Platform_numberOfFields = 100;
-char* Process_pidFormat = "%7u ";
 
 int Platform_getUptime() {
    struct timeval bootTime, currTime;

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -23,7 +23,6 @@ extern MeterClass* Platform_meterTypes[];
 void Platform_setBindings(Htop_Action* keys);
 
 extern int Platform_numberOfFields;
-extern char* Process_pidFormat;
 
 int Platform_getUptime();
 


### PR DESCRIPTION
My first contribution to the project :-)

Compilation on Mac OS X fails due to duplicate and conflicting declarations of `Process_pidFormat`.

`darwin/Platform.c` declares `char* Process_pidFormat` while `process.c` declares `char Process_pidFormat[20]`, and there are some extern declarations on other places referring to _it_ as well.

I did a blind-fix just to compile and get it running on OS X - I haven't analysed the code to understand the logic behind having different declarations, and mainly if my changes will affect the behaviour in other platforms, so **be cautions on accepting this PR**.

Another important thing is that `autogen.sh` did fail on my OS X (10.10.5) because it couldn't find `libtoolize` (which doesn't seem to come with Xcode, nor is provided by Homebrew), so I did run `glibtoolize` instead, which does the equivalent.

Finally, nice work on getting it to run on Darwin! :-) Kudos!