### PR TITLE
Detect whether to use libtoolize or glibtoolize.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,9 +1,23 @@
 #!/bin/sh
 
+# libtoolize verification thanks to libuv
+if [ "$LIBTOOLIZE" = "" ] && [ "`uname`" = "Darwin" ]; then
+    if command -v "glibtoolize" >/dev/null; then
+        LIBTOOLIZE=glibtoolize
+    elif command -v "libtoolize" >/dev/null; then
+        LIBTOOLIZE=libtoolize
+    else
+        echo "autogen.sh: line $LINENO: command glibtoolize or libtoolize not found"
+        exit 1
+    fi
+fi
+
+LIBTOOLIZE=${LIBTOOLIZE:-libtoolize}
+
 aclocal -I m4
 autoconf
 autoheader
-libtoolize --copy --force
+"$LIBTOOLIZE" --copy --force
 automake --add-missing --copy
 
 


### PR DESCRIPTION
Answering https://github.com/hishamhm/htop/pull/268#issuecomment-139357377, `glibtoolize` is provided by Homebrew in the `libtool` package.

> $ brew ls libtool | grep /bin/glibtoolize
> /usr/local/Cellar/libtool/2.4.6/bin/glibtoolize

Btw, `libncursesw` doesn't seem to be available in Darwin either (not sure though), so I disabled unicode via `./configure --disable-unicode`. Will need to take a better look later.