### PR TITLE
Unless I move signal definitions into the "generator" comment...

### DIFF
--- a/SignalsPanel.c
+++ b/SignalsPanel.c
@@ -31,6 +31,6 @@ Panel* SignalsPanel_new() {
    for(unsigned int i = 0; i < Platform_numberOfSignals; i++)
       Panel_set(this, i, (Object*) ListItem_new(Platform_signals[i].name, Platform_signals[i].number));
    Panel_setHeader(this, "Send signal:");
-   Panel_setSelected(this, 16); // 16th item is SIGTERM
+   Panel_setSelected(this, DEFAULT_SIGNAL);
    return this;
 }

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -31,12 +31,6 @@ in the source distribution for its full text.
 
 extern ProcessFieldData Process_fields[];
 
-}*/
-
-ProcessField Platform_defaultFields[] = { PID, USER, PRIORITY, NICE, M_SIZE, M_RESIDENT, STATE, PERCENT_CPU, PERCENT_MEM, TIME, COMM, 0 };
-
-int Platform_numberOfFields = LAST_PROCESSFIELD;
-
 static SignalItem Platform_signals[] = {
    { .name = " 0 Cancel",    .number =  0 },
    { .name = " 1 SIGHUP",    .number =  1 },
@@ -74,6 +68,12 @@ static SignalItem Platform_signals[] = {
    { .name = "33 SIGLIBRT",  .number = 33 },
 };
 
+}*/
+
+ProcessField Platform_defaultFields[] = { PID, USER, PRIORITY, NICE, M_SIZE, M_RESIDENT, STATE, PERCENT_CPU, PERCENT_MEM, TIME, COMM, 0 };
+
+int Platform_numberOfFields = LAST_PROCESSFIELD;
+
 unsigned int Platform_numberOfSignals = sizeof(Platform_signals)/sizeof(SignalItem);
 
 void Platform_setBindings(Htop_Action* keys) {
@@ -105,7 +105,7 @@ int Platform_getUptime() {
    struct timeval bootTime, currTime;
    int mib[2] = { CTL_KERN, KERN_BOOTTIME };
    size_t size = sizeof(bootTime);
-   
+
    int err = sysctl(mib, 2, &bootTime, &size, NULL, 0);
    if (err) {
       return -1;
@@ -119,7 +119,7 @@ void Platform_getLoadAverage(double* one, double* five, double* fifteen) {
    struct loadavg loadAverage;
    int mib[2] = { CTL_VM, VM_LOADAVG };
    size_t size = sizeof(loadAverage);
-   
+
    int err = sysctl(mib, 2, &loadAverage, &size, NULL, 0);
    if (err) {
       *one = 0;

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -31,6 +31,10 @@ in the source distribution for its full text.
 
 extern ProcessFieldData Process_fields[];
 
+#ifndef DEFAULT_SIGNAL
+#define DEFAULT_SIGNAL 15
+#endif
+
 static SignalItem Platform_signals[] = {
    { .name = " 0 Cancel",    .number =  0 },
    { .name = " 1 SIGHUP",    .number =  1 },

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -32,6 +32,11 @@ in the source distribution for its full text.
 #include "BatteryMeter.h"
 #include "LinuxProcess.h"
 #include "SignalsPanel.h"
+
+#ifndef DEFAULT_SIGNAL
+#define DEFAULT_SIGNAL 16
+#endif
+
 }*/
 
 ProcessField Platform_defaultFields[] = { PID, USER, PRIORITY, NICE, M_SIZE, M_RESIDENT, M_SHARE, STATE, PERCENT_CPU, PERCENT_MEM, TIME, COMM, 0 };
@@ -176,14 +181,14 @@ double Platform_setCPUValues(Meter* this, int cpu) {
          percent = v[0]+v[1]+v[2]+v[3]+v[4]+v[5]+v[6];
       } else {
          percent = v[0]+v[1]+v[2]+v[3]+v[4];
-      }       
+      }
    } else {
       v[2] = cpuData->systemAllPeriod / total * 100.0;
       v[3] = (cpuData->stealPeriod + cpuData->guestPeriod) / total * 100.0;
       Meter_setItems(this, 4);
       percent = v[0]+v[1]+v[2]+v[3];
    }
-   percent = MIN(100.0, MAX(0.0, percent));      
+   percent = MIN(100.0, MAX(0.0, percent));
    if (isnan(percent)) percent = 0.0;
    return percent;
 }


### PR DESCRIPTION
htop fails to compile with:

```text
SignalsPanel.c:32:49: error: use of undeclared identifier 'Platform_signals'
      Panel_set(this, i, (Object*) ListItem_new(Platform_signals[i].name, Platform_signals[i].number));
                                                ^
1 error generated.
*** Error code 1
```