### PR TITLE
adding "SignalsPanel.h" to imports to make it compile again on OS X

### DIFF
--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -22,6 +22,7 @@ in the source distribution for its full text.
 /*{
 #include "Action.h"
 #include "BatteryMeter.h"
+#include "SignalsPanel.h"
 #include "DarwinProcess.h"
 }*/
 


### PR DESCRIPTION
Previous commit added only the SignalPanels support without adding SignalItem definition. 
=> compiling fails on OS X.
This is fixed with simply adding the relevant header file to the imports of darwin/Platform.c