### PR TITLE
OpenBSD port updates and error exit improvements

### DIFF
--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -40,14 +40,14 @@ void ProcessList_getHostInfo(host_basic_info_data_t *p) {
    mach_msg_type_number_t info_size = HOST_BASIC_INFO_COUNT;
 
    if(0 != host_info(mach_host_self(), HOST_BASIC_INFO, (host_info_t)p, &info_size)) {
-       err(2, "Unable to retrieve host info\n");
+       CRT_fatalError("Unable to retrieve host info\n");
    }
 }
 
 void ProcessList_freeCPULoadInfo(processor_cpu_load_info_t *p) {
    if(NULL != p && NULL != *p) {
        if(0 != munmap(*p, vm_page_size)) {
-           err(8, "Unable to free old CPU load information\n");
+           CRT_fatalError("Unable to free old CPU load information\n");
        }
    }
 
@@ -60,7 +60,7 @@ unsigned ProcessList_allocateCPULoadInfo(processor_cpu_load_info_t *p) {
 
    // TODO Improving the accuracy of the load counts woule help a lot.
    if(0 != host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO, &cpu_count, (processor_info_array_t *)p, &info_size)) {
-       err(4, "Unable to retrieve CPU info\n");
+       CRT_fatalError("Unable to retrieve CPU info\n");
    }
 
    return cpu_count;
@@ -70,7 +70,7 @@ void ProcessList_getVMStats(vm_statistics64_t p) {
     mach_msg_type_number_t info_size = HOST_VM_INFO64_COUNT;
 
     if (host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info_t)p, &info_size) != 0)
-       err(9, "Unable to retrieve VM statistics\n");
+       CRT_fatalError("Unable to retrieve VM statistics\n");
 }
 
 struct kinfo_proc *ProcessList_getKInfoProcs(size_t *count) {
@@ -83,14 +83,14 @@ struct kinfo_proc *ProcessList_getKInfoProcs(size_t *count) {
     */
    *count = 0;
    if (sysctl(mib, 4, NULL, count, NULL, 0) < 0)
-      err(5, "Unable to get size of kproc_infos");
+      CRT_fatalError("Unable to get size of kproc_infos");
 
    processes = malloc(*count);
    if (processes == NULL)
-      errx(6, "Out of memory for kproc_infos");
+      CRT_fatalError("Out of memory for kproc_infos");
 
    if (sysctl(mib, 4, processes, count, NULL, 0) < 0)
-      err(7, "Unable to get kinfo_procs");
+      CRT_fatalError("Unable to get kinfo_procs");
 
    *count = *count / sizeof(struct kinfo_proc);
 

--- a/openbsd/OpenBSDProcessList.c
+++ b/openbsd/OpenBSDProcessList.c
@@ -52,7 +52,7 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, ui
    OpenBSDProcessList* fpl = calloc(1, sizeof(OpenBSDProcessList));
    ProcessList* pl = (ProcessList*) fpl;
    size_t size = sizeof(pl->cpuCount);
-   
+
    ProcessList_init(pl, Class(OpenBSDProcess), usersTable, pidWhiteList, userId);
    pl->cpuCount = 1;    // default to 1 on sysctl() error
    (void)sysctl(mib, 2, &pl->cpuCount, &size, NULL, 0);
@@ -66,7 +66,7 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, ui
       fpl->cpus[i].totalTime = 1;
       fpl->cpus[i].totalPeriod = 1;
    }
-   
+
    pageSizeKb = PAGE_SIZE_KB;
 
    // XXX: last arg should eventually be an errbuf
@@ -79,7 +79,7 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, ui
 void ProcessList_delete(ProcessList* this) {
    const OpenBSDProcessList* fpl = (OpenBSDProcessList*) this;
    if (fpl->kd) kvm_close(fpl->kd);
-  
+
    ProcessList_done(this);
    free(this);
 }
@@ -99,7 +99,7 @@ static inline void OpenBSDProcessList_scanMemoryInfo(ProcessList* pl) {
 
    /*
    const OpenBSDProcessList* fpl = (OpenBSDProcessList*) pl;
-   
+
    size_t len = sizeof(pl->totalMem);
    sysctl(MIB_hw_physmem, 2, &(pl->totalMem), &len, NULL, 0);
    pl->totalMem /= 1024;
@@ -108,7 +108,7 @@ static inline void OpenBSDProcessList_scanMemoryInfo(ProcessList* pl) {
    pl->freeMem = pl->totalMem - pl->usedMem;
    sysctl(MIB_vm_stats_vm_v_cache_count, 4, &(pl->cachedMem), &len, NULL, 0);
    pl->cachedMem *= pageSizeKb;
-   
+
    struct kvm_swap swap[16];
    int nswap = kvm_getswapinfo(fpl->kd, swap, sizeof(swap)/sizeof(swap[0]), 0);
    pl->totalSwap = 0;
@@ -119,7 +119,7 @@ static inline void OpenBSDProcessList_scanMemoryInfo(ProcessList* pl) {
    }
    pl->totalSwap *= pageSizeKb;
    pl->usedSwap *= pageSizeKb;
-   
+
    pl->sharedMem = 0;  // currently unused
    pl->buffersMem = 0; // not exposed to userspace
    */
@@ -179,23 +179,23 @@ void ProcessList_goThroughEntries(ProcessList* this) {
    OpenBSDProcess* fp;
    int count = 0;
    int i;
-   
+
    OpenBSDProcessList_scanMemoryInfo(this);
-   
+
    // use KERN_PROC_KTHREAD to also include kernel threads
    struct kinfo_proc* kprocs = kvm_getprocs(fpl->kd, KERN_PROC_ALL, 0, sizeof(struct kinfo_proc), &count);
    //struct kinfo_proc* kprocs = getprocs(KERN_PROC_ALL, 0, &count);
-   
+
    for (i = 0; i < count; i++) {
       kproc = &kprocs[i];
-      
+
       preExisting = false;
       proc = ProcessList_getProcess(this, kproc->p_pid, &preExisting, (Process_New) OpenBSDProcess_new);
       fp = (OpenBSDProcess*) proc;
 
       proc->show = ! ((hideKernelThreads && Process_isKernelThread(proc))
                   || (hideUserlandThreads && Process_isUserlandThread(proc)));
-      
+
       if (!preExisting) {
          proc->ppid = kproc->p_ppid;
          proc->tpgid = kproc->p_tpgid;
@@ -240,7 +240,7 @@ void ProcessList_goThroughEntries(ProcessList* this) {
       if (Process_isKernelThread(proc)) {
          this->kernelThreads++;
       }
-      
+
       this->totalTasks++;
       // SRUN ('R') means runnable, not running
       if (proc->state == 'P') {

--- a/openbsd/OpenBSDProcessList.c
+++ b/openbsd/OpenBSDProcessList.c
@@ -13,7 +13,6 @@ in the source distribution for its full text.
 #include <unistd.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <err.h>
 #include <sys/types.h>
 #include <sys/param.h>
 #include <sys/proc.h>
@@ -60,7 +59,7 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, ui
 
    size = sizeof(fscale);
    if (sysctl(fmib, 2, &fscale, &size, NULL, 0) < 0)
-     err(1, "fscale sysctl call failed");
+     CRT_fatalError("fscale sysctl call failed");
 
    for (i = 0; i < pl->cpuCount; i++) {
       fpl->cpus[i].totalTime = 1;
@@ -90,7 +89,7 @@ static inline void OpenBSDProcessList_scanMemoryInfo(ProcessList* pl) {
    size_t size = sizeof(uvmexp);
 
    if (sysctl(uvmexp_mib, 2, &uvmexp, &size, NULL, 0) < 0) {
-      err(1, "uvmexp sysctl call failed");
+      CRT_fatalError("uvmexp sysctl call failed");
    }
 
    //kb_pagesize = uvmexp.pagesize / 1024;
@@ -133,11 +132,11 @@ char *OpenBSDProcessList_readProcessName(kvm_t* kd, struct kinfo_proc* kproc, in
    argv = kvm_getargv(kd, kproc, 500);
 
    if (argv == NULL)
-      err(1, "kvm call failed");
+      CRT_fatalError("kvm call failed");
 
    str = buf = malloc(len+1);
    if (str == NULL)
-      err(1, "out of memory");
+      CRT_fatalError("out of memory");
 
    while (*argv != NULL) {
       cpsz = MIN(len, strlen(*argv));

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -38,6 +38,7 @@ in the source distribution for its full text.
 /*{
 #include "Action.h"
 #include "BatteryMeter.h"
+#include "SignalsPanel.h"
 
 extern ProcessFieldData Process_fields[];
 
@@ -231,7 +232,7 @@ double Platform_setCPUValues(Meter* this, int cpu) {
    if (perc <= 100. && perc >= 0.) {
       return perc;
    } else {
-      return 12.34;
+      return 0.;
    }
 }
 

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -167,7 +167,7 @@ int Platform_getUptime() {
    struct timeval bootTime, currTime;
    int mib[2] = { CTL_KERN, KERN_BOOTTIME };
    size_t size = sizeof(bootTime);
-   
+
    int err = sysctl(mib, 2, &bootTime, &size, NULL, 0);
    if (err) {
       return -1;
@@ -181,7 +181,7 @@ void Platform_getLoadAverage(double* one, double* five, double* fifteen) {
    struct loadavg loadAverage;
    int mib[2] = { CTL_VM, VM_LOADAVG };
    size_t size = sizeof(loadAverage);
-   
+
    int err = sysctl(mib, 2, &loadAverage, &size, NULL, 0);
    if (err) {
       *one = 0;

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -210,8 +210,7 @@ double Platform_setCPUValues(Meter* this, int cpu) {
    size_t size = sizeof(double) * CPUSTATES;
    int mib[] = { CTL_KERN, KERN_CPTIME2, cpu-1 };
    if (sysctl(mib, 3, new_v, &size, NULL, 0) == -1) {
-      puts("err!");
-      //return 0.;
+      return 0.;
    }
 
    // XXX: why?

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -36,6 +36,9 @@ extern ProcessField Platform_defaultFields[];
 
 extern int Platform_numberOfFields;
 
+/*
+ * See /usr/include/sys/signal.h
+ */
 extern SignalItem Platform_signals[];
 
 extern unsigned int Platform_numberOfSignals;


### PR DESCRIPTION
I've occasionally tweaked my OpenBSD port, so this includes a few diffs related to that.

In the process, I noticed that exiting without calling `CRT_done()` corrupts the terminal. So, I also converted all calls to `err.h` functions. We should do a second pass soon looking for all calls to `exit()`.

This changes behavior slightly by making all error exit codes `2`. I doubt that matters, though. Let me know if it might.