### PR TITLE
match load averages description to what it actually shows

### DIFF
--- a/LoadAverageMeter.c
+++ b/LoadAverageMeter.c
@@ -65,7 +65,7 @@ MeterClass LoadAverageMeter_class = {
    .attributes = LoadAverageMeter_attributes,
    .name = "LoadAverage",
    .uiName = "Load average",
-   .description = "Load averages: 15 minutes, 5 minutes, 1 minute",
+   .description = "Load averages: 1 minute, 5 minutes, 15 minutes",
    .caption = "Load average: "
 };
 


### PR DESCRIPTION
in htop setup of the meters there is a short description to every meter. 
I noticed the load average meter shows the 1 min average, 5 min average and 15 min average. 
In the description it says "15 minutes, 5 minutes, 1 minute". 
Therefore I changed this description to actually match the data which is shown. 