### PR TITLE
Redraw the panel when resizing the window during an incremental search

### DIFF
--- a/IncSet.c
+++ b/IncSet.c
@@ -169,6 +169,8 @@ bool IncSet_handleKey(IncSet* this, int ch, Panel* panel, IncMode_GetPanelValue 
             IncMode_reset(mode);
          }
       }
+   } else if (ch == KEY_RESIZE) {
+     Panel_resize(panel, COLS, LINES-panel->y-1);
    } else {
       if (mode->isFilter) {
          filterChanged = true;


### PR DESCRIPTION
`KEY_RESIZE` wasn't handled by the incremental search. Resulting in this
bug:

  * Set your terminal window to a small size.
  * Press `'\'` to filter the processes
  * Maximize your terminal window
  * The list of processes didn't resize.

This change fixes this bug.

Thank you Julian Andrews (@julianandrews) for finding this bug.