### PR TITLE
major meters update

### DIFF
--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -224,6 +224,10 @@ void ProcessList_goThroughEntries(ProcessList* this) {
             free(fp->jname);
             fp->jname = FreeBSDProcessList_readJailName(kproc);
          }
+         if(proc->st_uid != kproc->ki_uid) {
+            proc->st_uid = kproc->ki_uid;
+            proc->user = UsersTable_getRef(this->usersTable, proc->st_uid);
+         }
          if (settings->updateProcessNames) {
             free(proc->comm);
             proc->comm = FreeBSDProcessList_readProcessName(fpl->kd, kproc, &proc->basenameOffset);

--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -441,6 +441,7 @@ void ProcessList_goThroughEntries(ProcessList* this) {
            fp->kernel = 1;
          else
            fp->kernel = 0;
+         proc->ppid = kproc->ki_ppid;
          proc->tpgid = kproc->ki_tpgid;
          proc->tgid = kproc->ki_pid;
          proc->session = kproc->ki_sid;

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -178,6 +178,12 @@ double Platform_setCPUValues(Meter* this, int cpu) {
 
 void Platform_setMemoryValues(Meter* this) {
    // TODO
+   ProcessList* pl = (ProcessList*) this->pl;
+
+   this->total = pl->totalMem;
+   this->values[0] = pl->usedMem;
+   this->values[1] = pl->buffersMem;
+   this->values[2] = pl->cachedMem;
 }
 
 void Platform_setSwapValues(Meter* this) {

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -187,7 +187,9 @@ void Platform_setMemoryValues(Meter* this) {
 }
 
 void Platform_setSwapValues(Meter* this) {
-   // TODO
+   ProcessList* pl = (ProcessList*) this->pl;
+   this->total = pl->totalSwap;
+   this->values[0] = pl->usedSwap;
 }
 
 void Platform_setTasksValues(Meter* this) {

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -16,6 +16,7 @@ in the source distribution for its full text.
 #include "ClockMeter.h"
 #include "HostnameMeter.h"
 #include "FreeBSDProcess.h"
+#include "FreeBSDProcessList.h"
 
 #include <sys/types.h>
 #include <sys/sysctl.h>
@@ -105,7 +106,7 @@ int Platform_getUptime() {
    struct timeval bootTime, currTime;
    int mib[2] = { CTL_KERN, KERN_BOOTTIME };
    size_t size = sizeof(bootTime);
-   
+
    int err = sysctl(mib, 2, &bootTime, &size, NULL, 0);
    if (err) {
       return -1;
@@ -119,7 +120,7 @@ void Platform_getLoadAverage(double* one, double* five, double* fifteen) {
    struct loadavg loadAverage;
    int mib[2] = { CTL_VM, VM_LOADAVG };
    size_t size = sizeof(loadAverage);
-   
+
    int err = sysctl(mib, 2, &loadAverage, &size, NULL, 0);
    if (err) {
       *one = 0;
@@ -143,7 +144,36 @@ int Platform_getMaxPid() {
 }
 
 double Platform_setCPUValues(Meter* this, int cpu) {
-   // TODO
+   FreeBSDProcessList* fpl = (FreeBSDProcessList*) this->pl;
+   int cpus = this->pl->cpuCount;
+   CPUData* cpuData;
+
+   if (cpus == 1) {
+     // single CPU box has everything in fpl->cpus[0]
+     cpuData = &(fpl->cpus[0]);
+   } else {
+     cpuData = &(fpl->cpus[cpu]);
+   }
+
+   double  percent;
+   double* v = this->values;
+
+   v[CPU_METER_NICE]   = cpuData->nicePercent;
+   v[CPU_METER_NORMAL] = cpuData->userPercent;
+   if (this->pl->settings->detailedCPUTime) {
+      v[CPU_METER_KERNEL]  = cpuData->systemPercent;
+      v[CPU_METER_IRQ]     = cpuData->irqPercent;
+      Meter_setItems(this, 4);
+      percent = v[0]+v[1]+v[2]+v[3];
+   } else {
+      v[2] = cpuData->systemAllPercent;
+      Meter_setItems(this, 3);
+      percent = v[0]+v[1]+v[2];
+   }
+
+   percent = MIN(100.0, MAX(0.0, percent));
+   if (isnan(percent)) percent = 0.0;
+   return percent;
 }
 
 void Platform_setMemoryValues(Meter* this) {


### PR DESCRIPTION
With these changes all major meters should be covered and htop is finally completely usable on FreeBSD, without Linux procfs emulation. One less module to load into kernel.

Some values like CPU usage per process are lifted directly from kernel and are not that precise, but for an interactive program it's enough, I believe. User can always invoke native top or ps for more details.

Added bonus is jails support, which now makes inspection of jail heavy machines a breeze. 

I hope the code is up to your standard as I am not a C coder. I am interested in extending a memory meter, but I still don't understand many things.