### PR TITLE
Fix text on function bar when moving meters.

### DIFF
--- a/MetersPanel.c
+++ b/MetersPanel.c
@@ -36,7 +36,7 @@ static const char* MetersKeys[] = {"Space", "Enter", "Del", "Esc"};
 static int MetersEvents[] = {' ', 13, KEY_DC, 27};
 
 static const char* MetersMovingFunctions[] = {"Up    ", "Down  ", "Left  ", "Right ",  "Confirm", "Delete", "Done  ", NULL};
-static const char* MetersMovingKeys[] = {"Up", "Dn", "Lt", "Rt", "Arrows", "Enter", "Del", "Esc"};
+static const char* MetersMovingKeys[] = {"Up", "Dn", "Lt", "Rt", "Enter", "Del", "Esc"};
 static int MetersMovingEvents[] = {KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT, 13, KEY_DC, 27};
 static FunctionBar* Meters_movingBar = NULL;
 


### PR DESCRIPTION
Before:
[Up]Up [Dn]Down [Lt]Left [Rt]Right [Arrow]Confirm [Enter]Delete [Del]Done

After:
[Up]Up [Dn]Down [Lt]Left [Rt]Right [Enter]Confirm [Del]Delete [Esc]Done

This is just a minor fix on the description text. For usability perspective, having both "Confirm" and "Done"  actions can be confusing when a Meter is selected to move. I will suggest removing the [Esc]Done key action or change to something intuitive, such as "Cancel" (and undo the move).

