### PR TITLE
[Experimental] Graph meter coloring by items.

### DIFF
--- a/Meter.c
+++ b/Meter.c
@@ -421,7 +421,6 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
       double *prevItemSums = data->prevItemSums;
       double *currentItemSums = data->currentItemSums;
       
-      currentItemSums[0] = this->values[0];
       for (int i = 0; i < items; i++) {
          prevItemSums[i] = currentItemSums[i];
          currentItemSums[i] = ((i > 0) ? currentItemSums[i-1] : 0.0) + this->values[i];

--- a/Meter.c
+++ b/Meter.c
@@ -451,9 +451,9 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
    }
    
    for (int i = nValues - (w*2) + 2, k = 0; i < nValues; i+=2, k++) {
-      const double dot = (1.0 / (GraphMeterMode_pixPerRow * GRAPH_HEIGHT));
-      int v1 = MIN(GraphMeterMode_pixPerRow * GRAPH_HEIGHT, MAX(1, data->values[i] / dot));
-      int v2 = MIN(GraphMeterMode_pixPerRow * GRAPH_HEIGHT, MAX(1, data->values[i+1] / dot));
+      int pix = GraphMeterMode_pixPerRow * GRAPH_HEIGHT;
+      int v1 = MIN(pix, MAX(1, data->values[i] * pix));
+      int v2 = MIN(pix, MAX(1, data->values[i+1] * pix));
 
       for (int line = 0; line < GRAPH_HEIGHT; line++) {
          int line1 = MIN(GraphMeterMode_pixPerRow, MAX(0, v1 - (GraphMeterMode_pixPerRow * (GRAPH_HEIGHT - 1 - line))));

--- a/Meter.c
+++ b/Meter.c
@@ -425,7 +425,7 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
       currentItemSums[0] = this->values[0];
       for (int i = 0; i < items; i++) {
          prevItemSums[i] = currentItemSums[i];
-         currentItemSums[i] = ((i > 0) ? currentItemSums[i-1] : 0) + this->values[i];
+         currentItemSums[i] = ((i > 0) ? currentItemSums[i-1] : 0.0) + this->values[i];
       }
       data->values[nValues - 1] = currentItemSums[items - 1] / this->total;
 
@@ -439,8 +439,8 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
              double lowerBound = this->total * (GRAPH_HEIGHT - 1 - line) / GRAPH_HEIGHT;
              area = MAX(lowerBound, MIN(currentItemSums[i], upperBound)) +
                     MAX(lowerBound, MIN(prevItemSums[i], upperBound));
-             area -= MAX(lowerBound, MIN(((i > 0) ? currentItemSums[i-1] : 0), upperBound)) +
-                     MAX(lowerBound, MIN(((i > 0) ? prevItemSums[i-1] : 0), upperBound));
+             area -= MAX(lowerBound, MIN(((i > 0) ? currentItemSums[i-1] : 0.0), upperBound)) +
+                     MAX(lowerBound, MIN(((i > 0) ? prevItemSums[i-1] : 0.0), upperBound));
              if (area > maxArea) {
                 maxArea = area;
                 dominantColor = CRT_colors[Meter_attributes(this)[i]];

--- a/Meter.c
+++ b/Meter.c
@@ -374,7 +374,7 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
       GraphData* data = (GraphData*) this->drawData;
       for (int i = 0; i < nValues; i++) {
          for (int line = 0; line < GRAPH_HEIGHT; line++) {
-            data->colors[i][line] = CRT_colors[BAR_SHADOW];
+            data->colors[i][line] = BAR_SHADOW;
          }
       }
    }
@@ -431,7 +431,7 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
 
       // Determine the dominant color of the cell in graph
       for (int line = 0; line < GRAPH_HEIGHT; line++) {
-         int dominantColor = CRT_colors[BAR_SHADOW];
+         int dominantColor = BAR_SHADOW;
          double maxArea = 0.0;
          for (int i = 0; i < items; i++) {
              double area;
@@ -443,7 +443,7 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
                      MAX(lowerBound, MIN(((i > 0) ? prevItemSums[i-1] : 0.0), upperBound));
              if (area > maxArea) {
                 maxArea = area;
-                dominantColor = CRT_colors[Meter_attributes(this)[i]];
+                dominantColor = Meter_attributes(this)[i];
              }
          }
          data->colors[nValues - 1][line] = dominantColor;
@@ -459,7 +459,7 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
          int line1 = MIN(GraphMeterMode_pixPerRow, MAX(0, v1 - (GraphMeterMode_pixPerRow * (GRAPH_HEIGHT - 1 - line))));
          int line2 = MIN(GraphMeterMode_pixPerRow, MAX(0, v2 - (GraphMeterMode_pixPerRow * (GRAPH_HEIGHT - 1 - line))));
          
-         attrset(data->colors[i+1][line]);
+         attrset(CRT_colors[data->colors[i+1][line]]);
          mvaddstr(y+line, x+k, GraphMeterMode_dots[line1 * (GraphMeterMode_pixPerRow + 1) + line2]);
       }
    }

--- a/Meter.c
+++ b/Meter.c
@@ -435,10 +435,12 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
          double maxArea = 0.0;
          for (int i = 0; i < items; i++) {
              double area;
-             area = MIN(currentItemSums[i], this->total * (GRAPH_HEIGHT - line) / GRAPH_HEIGHT) +
-                    MIN(prevItemSums[i], this->total * (GRAPH_HEIGHT - line) / GRAPH_HEIGHT);
-             area -= MAX(((i > 0) ? currentItemSums[i-1] : 0), this->total * (GRAPH_HEIGHT - 1 - line) / GRAPH_HEIGHT) +
-                     MAX(((i > 0) ? currentItemSums[i-1] : 0), this->total * (GRAPH_HEIGHT - 1 - line) / GRAPH_HEIGHT);
+             double upperBound = this->total * (GRAPH_HEIGHT - line) / GRAPH_HEIGHT;
+             double lowerBound = this->total * (GRAPH_HEIGHT - 1 - line) / GRAPH_HEIGHT;
+             area = MAX(lowerBound, MIN(currentItemSums[i], upperBound)) +
+                    MAX(lowerBound, MIN(prevItemSums[i], upperBound));
+             area -= MAX(lowerBound, MIN(((i > 0) ? currentItemSums[i-1] : 0), upperBound)) +
+                     MAX(lowerBound, MIN(((i > 0) ? prevItemSums[i-1] : 0), upperBound));
              if (area > maxArea) {
                 maxArea = area;
                 dominantColor = CRT_colors[Meter_attributes(this)[i]];

--- a/Meter.c
+++ b/Meter.c
@@ -70,6 +70,7 @@ typedef struct MeterClass_ {
 #define Meter_defaultMode(this_)       As_Meter(this_)->defaultMode
 #define Meter_getItems(this_)          As_Meter(this_)->curItems
 #define Meter_setItems(this_, n_)      As_Meter(this_)->curItems = (n_)
+#define Meter_getMaxItems(this_)       As_Meter(this_)->maxItems
 #define Meter_attributes(this_)        As_Meter(this_)->attributes
 #define Meter_name(this_)              As_Meter(this_)->name
 #define Meter_uiName(this_)            As_Meter(this_)->uiName
@@ -372,6 +373,10 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
    if (!this->drawData) {
       this->drawData = calloc(1, sizeof(GraphData));
       GraphData* data = (GraphData*) this->drawData;
+      if (!data->prevItemSums)
+         data->prevItemSums = calloc(Meter_getMaxItems(this), sizeof(*data->prevItemSums));
+      if (!data->currentItemSums)
+         data->currentItemSums = calloc(Meter_getMaxItems(this), sizeof(*data->currentItemSums));
       for (int i = 0; i < nValues; i++) {
          for (int line = 0; line < GRAPH_HEIGHT; line++) {
             data->colors[i][line] = BAR_SHADOW;
@@ -413,12 +418,6 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
 
       int items = Meter_getItems(this);
 
-      if (!data->prevItemSums) {
-         data->prevItemSums = calloc(items, sizeof(*data->prevItemSums));
-      }
-      if (!data->currentItemSums) {
-         data->currentItemSums = calloc(items, sizeof(*data->currentItemSums));
-      }
       double *prevItemSums = data->prevItemSums;
       double *currentItemSums = data->currentItemSums;
       

--- a/Meter.c
+++ b/Meter.c
@@ -437,10 +437,8 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
              double area;
              area = MIN(currentItemSums[i], this->total * (GRAPH_HEIGHT - line) / GRAPH_HEIGHT) +
                     MIN(prevItemSums[i], this->total * (GRAPH_HEIGHT - line) / GRAPH_HEIGHT);
-             if (i > 0) {
-                area -= MAX(currentItemSums[i-1], this->total * (GRAPH_HEIGHT - 1 - line) / GRAPH_HEIGHT) +
-                        MAX(prevItemSums[i-1], this->total * (GRAPH_HEIGHT - 1 - line) / GRAPH_HEIGHT);
-             }
+             area -= MAX(((i > 0) ? currentItemSums[i-1] : 0), this->total * (GRAPH_HEIGHT - 1 - line) / GRAPH_HEIGHT) +
+                     MAX(((i > 0) ? currentItemSums[i-1] : 0), this->total * (GRAPH_HEIGHT - 1 - line) / GRAPH_HEIGHT);
              if (area > maxArea) {
                 maxArea = area;
                 dominantColor = CRT_colors[Meter_attributes(this)[i]];

--- a/Meter.c
+++ b/Meter.c
@@ -358,6 +358,8 @@ static const char* GraphMeterMode_dotsAscii[] = {
    /*20*/":", /*21*/":", /*22*/":"
 };
 
+#define GRAPH_HEIGHT 4 /* Unit: rows (lines) */
+
 static const char** GraphMeterMode_dots;
 static int GraphMeterMode_pixPerRow;
 
@@ -405,14 +407,14 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
    }
    
    for (int i = nValues - (w*2) + 2, k = 0; i < nValues; i+=2, k++) {
-      const double dot = (1.0 / (GraphMeterMode_pixPerRow * 4));
-      int v1 = MIN(GraphMeterMode_pixPerRow * 4, MAX(1, data->values[i] / dot));
-      int v2 = MIN(GraphMeterMode_pixPerRow * 4, MAX(1, data->values[i+1] / dot));
+      const double dot = (1.0 / (GraphMeterMode_pixPerRow * GRAPH_HEIGHT));
+      int v1 = MIN(GraphMeterMode_pixPerRow * GRAPH_HEIGHT, MAX(1, data->values[i] / dot));
+      int v2 = MIN(GraphMeterMode_pixPerRow * GRAPH_HEIGHT, MAX(1, data->values[i+1] / dot));
 
       int colorIdx = GRAPH_1;
-      for (int line = 0; line < 4; line++) {
-         int line1 = MIN(GraphMeterMode_pixPerRow, MAX(0, v1 - (GraphMeterMode_pixPerRow * (3 - line))));
-         int line2 = MIN(GraphMeterMode_pixPerRow, MAX(0, v2 - (GraphMeterMode_pixPerRow * (3 - line))));
+      for (int line = 0; line < GRAPH_HEIGHT; line++) {
+         int line1 = MIN(GraphMeterMode_pixPerRow, MAX(0, v1 - (GraphMeterMode_pixPerRow * (GRAPH_HEIGHT - 1 - line))));
+         int line2 = MIN(GraphMeterMode_pixPerRow, MAX(0, v2 - (GraphMeterMode_pixPerRow * (GRAPH_HEIGHT - 1 - line))));
 
          attrset(CRT_colors[colorIdx]);
          mvaddstr(y+line, x+k, GraphMeterMode_dots[line1 * (GraphMeterMode_pixPerRow + 1) + line2]);
@@ -500,7 +502,7 @@ static MeterMode TextMeterMode = {
 
 static MeterMode GraphMeterMode = {
    .uiName = "Graph",
-   .h = 4,
+   .h = GRAPH_HEIGHT,
    .draw = GraphMeterMode_draw,
 };
 

--- a/Meter.h
+++ b/Meter.h
@@ -57,6 +57,7 @@ typedef struct MeterClass_ {
 #define Meter_defaultMode(this_)       As_Meter(this_)->defaultMode
 #define Meter_getItems(this_)          As_Meter(this_)->curItems
 #define Meter_setItems(this_, n_)      As_Meter(this_)->curItems = (n_)
+#define Meter_getMaxItems(this_)       As_Meter(this_)->maxItems
 #define Meter_attributes(this_)        As_Meter(this_)->attributes
 #define Meter_name(this_)              As_Meter(this_)->name
 #define Meter_uiName(this_)            As_Meter(this_)->uiName

--- a/Meter.h
+++ b/Meter.h
@@ -13,6 +13,8 @@ in the source distribution for its full text.
 
 #define GRAPH_DELAY (DEFAULT_DELAY/2)
 
+#define GRAPH_HEIGHT 4 /* Unit: rows (lines) */
+
 #include "ListItem.h"
 
 #include <sys/time.h>
@@ -91,6 +93,9 @@ typedef enum {
 typedef struct GraphData_ {
    struct timeval time;
    double values[METER_BUFFER_LEN];
+   int colors[METER_BUFFER_LEN][GRAPH_HEIGHT];
+   double *prevItemSums;
+   double *currentItemSums;
 } GraphData;
 
 
@@ -127,8 +132,6 @@ ListItem* Meter_toListItem(Meter* this, bool moving);
 #endif
 
 #define PIXPERROW_ASCII 2
-#define GRAPH_HEIGHT 4 /* Unit: rows (lines) */
-
 
 /* ---------- LEDMeterMode ---------- */
 

--- a/Meter.h
+++ b/Meter.h
@@ -127,6 +127,8 @@ ListItem* Meter_toListItem(Meter* this, bool moving);
 #endif
 
 #define PIXPERROW_ASCII 2
+#define GRAPH_HEIGHT 4 /* Unit: rows (lines) */
+
 
 /* ---------- LEDMeterMode ---------- */
 


### PR DESCRIPTION
This patch colors the graph meter based on the items of the bar meter.
For example, if most of the CPU power is running on low-priority
processes, then blue will be shown on the graph columns. If most of the
CPU is running on kernel things, then the columns will be red, and so
on.

Update: My personal to-do list for now:
* [DONE] Figure out if there's a way to make the color determination faster. Currently it's O(items*graphHeight). Is  there a way to make it O(items+graphHeight)?
* Replace prevItemSums and currentItemSums with something more efficient. (Not sure if there is a better structure...)
* Rebase this branch from the current master branch. (This includes adopting the CLAMP macro.)
* [DONE] Fix memory leak on currentItemSums and prevItemSums .

I also need people to review it, ensuring that there are no problems in variables naming, data structures or memory allocation routines. (This is the first time I try such a big change in htop.)

![screenshot from 2015-12-24 17 35 01](https://cloud.githubusercontent.com/assets/2487263/11992796/0a438fc2-aa65-11e5-8535-a6b9c527a817.png)
