### PR TITLE
Darwin: replace vm_statistics64_* with vm_statistics_*

### DIFF
--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -28,7 +28,7 @@ typedef struct DarwinProcessList_ {
    ProcessList super;
 
    host_basic_info_data_t host_info;
-   vm_statistics64_data_t vm_stats;
+   vm_statistics_data_t vm_stats;
    processor_cpu_load_info_t prev_load;
    processor_cpu_load_info_t curr_load;
    uint64_t kernel_threads;
@@ -68,10 +68,10 @@ unsigned ProcessList_allocateCPULoadInfo(processor_cpu_load_info_t *p) {
    return cpu_count;
 }
 
-void ProcessList_getVMStats(vm_statistics64_t p) {
-    mach_msg_type_number_t info_size = HOST_VM_INFO64_COUNT;
+void ProcessList_getVMStats(vm_statistics_t p) {
+    mach_msg_type_number_t info_size = HOST_VM_INFO_COUNT;
 
-    if (host_statistics64(mach_host_self(), HOST_VM_INFO64, (host_info_t)p, &info_size) != 0)
+    if (host_statistics(mach_host_self(), HOST_VM_INFO, (host_info_t)p, &info_size) != 0)
        CRT_fatalError("Unable to retrieve VM statistics\n");
 }
 

--- a/darwin/DarwinProcessList.h
+++ b/darwin/DarwinProcessList.h
@@ -17,7 +17,7 @@ typedef struct DarwinProcessList_ {
    ProcessList super;
 
    host_basic_info_data_t host_info;
-   vm_statistics64_data_t vm_stats;
+   vm_statistics_data_t vm_stats;
    processor_cpu_load_info_t prev_load;
    processor_cpu_load_info_t curr_load;
    uint64_t kernel_threads;
@@ -32,7 +32,7 @@ void ProcessList_freeCPULoadInfo(processor_cpu_load_info_t *p);
 
 unsigned ProcessList_allocateCPULoadInfo(processor_cpu_load_info_t *p);
 
-void ProcessList_getVMStats(vm_statistics64_t p);
+void ProcessList_getVMStats(vm_statistics_t p);
 
 struct kinfo_proc *ProcessList_getKInfoProcs(size_t *count);
 

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -218,7 +218,7 @@ double Platform_setCPUValues(Meter* mtr, int cpu) {
 
 void Platform_setMemoryValues(Meter* mtr) {
    DarwinProcessList *dpl = (DarwinProcessList *)mtr->pl;
-   vm_statistics64_t vm = &dpl->vm_stats;
+   vm_statistics_t vm = &dpl->vm_stats;
    double page_K = (double)vm_page_size / (double)1024;
 
    mtr->total = dpl->host_info.max_mem / 1024;


### PR DESCRIPTION
This makes the latest and greatest htop compile and run on my trusty G5 iMac