### PR TITLE
Introduce CLAMP macro. Unify all MAX(l,MIN(h,x)) uses.

### DIFF
--- a/Meter.c
+++ b/Meter.c
@@ -114,6 +114,9 @@ typedef struct GraphData_ {
 #ifndef MAX
 #define MAX(a,b) ((a)>(b)?(a):(b))
 #endif
+#ifndef CLAMP
+#define CLAMP(x,low,high) (((x)>(high))?(high):(((x)<(low))?(low):(x)))
+#endif
 
 MeterClass Meter_class = {
    .super = {
@@ -297,8 +300,7 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
    int items = Meter_getItems(this);
    for (int i = 0; i < items; i++) {
       double value = this->values[i];
-      value = MAX(value, 0);
-      value = MIN(value, this->total);
+      value = CLAMP(value, 0.0, this->total);
       if (value > 0) {
          blockSizes[i] = ceil((value/this->total) * w);
       } else {
@@ -306,7 +308,7 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
       }
       int nextOffset = offset + blockSizes[i];
       // (Control against invalid values)
-      nextOffset = MIN(MAX(nextOffset, 0), w);
+      nextOffset = CLAMP(nextOffset, 0, w);
       for (int j = offset; j < nextOffset; j++)
          if (bar[j] == ' ') {
             if (CRT_colorScheme == COLORSCHEME_MONOCHROME) {
@@ -324,8 +326,7 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
       attrset(CRT_colors[Meter_attributes(this)[i]]);
       mvaddnstr(y, x + offset, bar + offset, blockSizes[i]);
       offset += blockSizes[i];
-      offset = MAX(offset, 0);
-      offset = MIN(offset, w);
+      offset = CLAMP(offset, 0, w);
    }
    if (offset < w) {
       attrset(CRT_colors[BAR_SHADOW]);
@@ -406,13 +407,13 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
    
    for (int i = nValues - (w*2) + 2, k = 0; i < nValues; i+=2, k++) {
       const double dot = (1.0 / (GraphMeterMode_pixPerRow * 4));
-      int v1 = MIN(GraphMeterMode_pixPerRow * 4, MAX(1, data->values[i] / dot));
-      int v2 = MIN(GraphMeterMode_pixPerRow * 4, MAX(1, data->values[i+1] / dot));
+      int v1 = CLAMP(data->values[i] / dot, 1, GraphMeterMode_pixPerRow * 4);
+      int v2 = CLAMP(data->values[i+1] / dot, 1, GraphMeterMode_pixPerRow * 4);
 
       int colorIdx = GRAPH_1;
       for (int line = 0; line < 4; line++) {
-         int line1 = MIN(GraphMeterMode_pixPerRow, MAX(0, v1 - (GraphMeterMode_pixPerRow * (3 - line))));
-         int line2 = MIN(GraphMeterMode_pixPerRow, MAX(0, v2 - (GraphMeterMode_pixPerRow * (3 - line))));
+         int line1 = CLAMP(v1 - (GraphMeterMode_pixPerRow * (3 - line)), 0, GraphMeterMode_pixPerRow);
+         int line2 = CLAMP(v2 - (GraphMeterMode_pixPerRow * (3 - line)), 0, GraphMeterMode_pixPerRow);
 
          attrset(CRT_colors[colorIdx]);
          mvaddstr(y+line, x+k, GraphMeterMode_dots[line1 * (GraphMeterMode_pixPerRow + 1) + line2]);

--- a/Meter.h
+++ b/Meter.h
@@ -100,6 +100,9 @@ typedef struct GraphData_ {
 #ifndef MAX
 #define MAX(a,b) ((a)>(b)?(a):(b))
 #endif
+#ifndef CLAMP
+#define CLAMP(x,low,high) (((x)>(high))?(high):(((x)<(low))?(low):(x)))
+#endif
 
 extern MeterClass Meter_class;
 

--- a/RichString.c
+++ b/RichString.c
@@ -62,10 +62,6 @@ typedef struct RichString_ {
 
 }*/
 
-#ifndef MIN
-#define MIN(a,b) ((a)<(b)?(a):(b))
-#endif
-
 #define charBytes(n) (sizeof(CharType) * (n)) 
 
 static void RichString_extendLen(RichString* this, int len) {

--- a/RichString.h
+++ b/RichString.h
@@ -59,10 +59,6 @@ typedef struct RichString_ {
 } RichString;
 
 
-#ifndef MIN
-#define MIN(a,b) ((a)<(b)?(a):(b))
-#endif
-
 #define charBytes(n) (sizeof(CharType) * (n)) 
 
 #define RichString_setLen(this, len) do{ if(len < RICHSTRING_MAXLEN && this->chlen < RICHSTRING_MAXLEN) { RichString_setChar(this,len,0); this->chlen=len; } else RichString_extendLen(this,len); }while(0)

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -27,6 +27,10 @@ in the source distribution for its full text.
 #include "DarwinProcess.h"
 }*/
 
+#ifndef CLAMP
+#define CLAMP(x,low,high) (((x)>(high))?(high):(((x)<(low))?(low):(x)))
+#endif
+
 ProcessField Platform_defaultFields[] = { PID, USER, PRIORITY, NICE, M_SIZE, M_RESIDENT, STATE, PERCENT_CPU, PERCENT_MEM, TIME, COMM, 0 };
 
 SignalItem Platform_signals[] = {
@@ -213,7 +217,7 @@ double Platform_setCPUValues(Meter* mtr, int cpu) {
    /* Convert to percent and return */
    total = mtr->values[CPU_METER_NICE] + mtr->values[CPU_METER_NORMAL] + mtr->values[CPU_METER_KERNEL];
 
-   return MIN(100.0, MAX(0.0, total));
+   return CLAMP(total, 0.0, 100.0);
 }
 
 void Platform_setMemoryValues(Meter* mtr) {

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -16,6 +16,10 @@ in the source distribution for its full text.
 #include "BatteryMeter.h"
 #include "DarwinProcess.h"
 
+#ifndef CLAMP
+#define CLAMP(x,low,high) (((x)>(high))?(high):(((x)<(low))?(low):(x)))
+#endif
+
 extern ProcessField Platform_defaultFields[];
 
 extern SignalItem Platform_signals[];

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -34,6 +34,10 @@ extern ProcessFieldData Process_fields[];
 
 }*/
 
+#ifndef CLAMP
+#define CLAMP(x,low,high) (((x)>(high))?(high):(((x)<(low))?(low):(x)))
+#endif
+
 ProcessField Platform_defaultFields[] = { PID, USER, PRIORITY, NICE, M_SIZE, M_RESIDENT, STATE, PERCENT_CPU, PERCENT_MEM, TIME, COMM, 0 };
 
 int Platform_numberOfFields = LAST_PROCESSFIELD;
@@ -171,7 +175,7 @@ double Platform_setCPUValues(Meter* this, int cpu) {
       percent = v[0]+v[1]+v[2];
    }
 
-   percent = MIN(100.0, MAX(0.0, percent));
+   percent = CLAMP(percent, 0.0, 100.0);
    if (isnan(percent)) percent = 0.0;
    return percent;
 }

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -16,6 +16,10 @@ in the source distribution for its full text.
 extern ProcessFieldData Process_fields[];
 
 
+#ifndef CLAMP
+#define CLAMP(x,low,high) (((x)>(high))?(high):(((x)<(low))?(low):(x)))
+#endif
+
 extern ProcessField Platform_defaultFields[];
 
 extern int Platform_numberOfFields;
@@ -41,5 +45,7 @@ void Platform_setMemoryValues(Meter* this);
 void Platform_setSwapValues(Meter* this);
 
 void Platform_setTasksValues(Meter* this);
+
+char* Platform_getProcessEnv(pid_t pid);
 
 #endif

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -83,6 +83,10 @@ typedef struct LinuxProcessList_ {
 #endif
 
 }*/
+
+#ifndef CLAMP
+#define CLAMP(x,low,high) (((x)>(high))?(high):(((x)<(low))?(low):(x)))
+#endif
    
 ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, uid_t userId) {
    LinuxProcessList* this = calloc(1, sizeof(LinuxProcessList));
@@ -540,7 +544,7 @@ static bool LinuxProcessList_recurseProcTree(LinuxProcessList* this, const char*
       if (settings->flags & PROCESS_FLAG_LINUX_IOPRIO)
          LinuxProcess_updateIOPriority(lp);
       float percent_cpu = (lp->utime + lp->stime - lasttimes) / period * 100.0;
-      proc->percent_cpu = MAX(MIN(percent_cpu, cpus*100.0), 0.0);
+      proc->percent_cpu = CLAMP(percent_cpu, 0.0, cpus * 100.0);
       if (isnan(proc->percent_cpu)) proc->percent_cpu = 0.0;
       proc->percent_mem = (proc->m_resident * PAGE_SIZE_KB) / (double)(pl->totalMem) * 100.0;
 

--- a/linux/LinuxProcessList.h
+++ b/linux/LinuxProcessList.h
@@ -63,6 +63,10 @@ typedef struct LinuxProcessList_ {
 #define PROC_LINE_LENGTH 512
 #endif
 
+
+#ifndef CLAMP
+#define CLAMP(x,low,high) (((x)>(high))?(high):(((x)<(low))?(low):(x)))
+#endif
    
 ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, uid_t userId);
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -37,6 +37,10 @@ in the source distribution for its full text.
 #include "SignalsPanel.h"
 }*/
 
+#ifndef CLAMP
+#define CLAMP(x,low,high) (((x)>(high))?(high):(((x)<(low))?(low):(x)))
+#endif
+
 ProcessField Platform_defaultFields[] = { PID, USER, PRIORITY, NICE, M_SIZE, M_RESIDENT, M_SHARE, STATE, PERCENT_CPU, PERCENT_MEM, TIME, COMM, 0 };
 
 //static ProcessField defaultIoFields[] = { PID, IO_PRIORITY, USER, IO_READ_RATE, IO_WRITE_RATE, IO_RATE, COMM, 0 };
@@ -186,7 +190,7 @@ double Platform_setCPUValues(Meter* this, int cpu) {
       Meter_setItems(this, 4);
       percent = v[0]+v[1]+v[2]+v[3];
    }
-   percent = MIN(100.0, MAX(0.0, percent));
+   percent = CLAMP(percent, 0.0, 100.0);
    if (isnan(percent)) percent = 0.0;
    return percent;
 }

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -15,6 +15,10 @@ in the source distribution for its full text.
 #include "LinuxProcess.h"
 #include "SignalsPanel.h"
 
+#ifndef CLAMP
+#define CLAMP(x,low,high) (((x)>(high))?(high):(((x)<(low))?(low):(x)))
+#endif
+
 extern ProcessField Platform_defaultFields[];
 
 extern int Platform_numberOfFields;

--- a/openbsd/OpenBSDProcessList.c
+++ b/openbsd/OpenBSDProcessList.c
@@ -42,6 +42,10 @@ typedef struct OpenBSDProcessList_ {
 
 }*/
 
+#ifndef CLAMP
+#define CLAMP(x,low,high) (((x)>(high))?(high):(((x)<(low))?(low):(x)))
+#endif
+
 static int pageSizeKb;
 static long fscale;
 
@@ -229,7 +233,7 @@ void ProcessList_goThroughEntries(ProcessList* this) {
       proc->m_size = kproc->p_vm_dsize;
       proc->m_resident = kproc->p_vm_rssize;
       proc->percent_mem = (proc->m_resident * PAGE_SIZE_KB) / (double)(this->totalMem) * 100.0;
-      proc->percent_cpu = MAX(MIN(getpcpu(kproc), this->cpuCount*100.0), 0.0);
+      proc->percent_cpu = CLAMP(getpcpu(kproc), 0.0, this->cpuCount*100.0);
       //proc->nlwp = kproc->p_numthreads;
       //proc->time = kproc->p_rtime_sec + ((kproc->p_rtime_usec + 500000) / 10);
       proc->nice = kproc->p_nice - 20;

--- a/openbsd/OpenBSDProcessList.h
+++ b/openbsd/OpenBSDProcessList.h
@@ -27,6 +27,10 @@ typedef struct OpenBSDProcessList_ {
 } OpenBSDProcessList;
 
 
+#ifndef CLAMP
+#define CLAMP(x,low,high) (((x)>(high))?(high):(((x)<(low))?(low):(x)))
+#endif
+
 
 ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, uid_t userId);
 


### PR DESCRIPTION
With the CLAMP macro replacing the combination of MIN and MAX, we will
have at least two advantages:
1. It's more obvious semantically.
2. There are no more mixes of confusing uses like MIN(MAX(a,b),c) and
   MAX(MIN(a,b),c) and MIN(a,MAX(b,c)) appearing everywhere. We unify
   the 'clamping' with a single macro.
Note that the behavior of this CLAMP macro is different from
the combination `MAX(low,MIN(x,high))`.
* This CLAMP macro expands to two comparisons instead of three from
  MAX and MIN combination. In theory, this makes the code slightly
  smaller, in case that (low) or (high) or both are computed at
  runtime, so that compilers cannot optimize them. (The third
  comparison will matter if (low)>(high); see below.)
* CLAMP has a side effect, that if (low)>(high) it will produce weird
  results. Unlike MIN & MAX which will force either (low) or (high) to
  win. No assertion of ((low)<=(high)) is done in this macro, for now.

This CLAMP macro is implemented like described in glib
<http://developer.gnome.org/glib/stable/glib-Standard-Macros.html>
and does not handle weird uses like CLAMP(a++, low++, high--) .

EDIT:Please ignore the commit 17c33119af1a284744fcc9ab7762b63647fc23d7 , the description on that commit is wrong (I discover that out after pushing it), the commit 6dae810 has a corrected description.