### PR TITLE
Graph meter coloring by items. (v4. Rebased on current master.)

### DIFF
--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -97,5 +97,6 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Count CPUs from 0 instead of 1"), &(settings->countCPUsFromZero)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Update process names on every refresh"), &(settings->updateProcessNames)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Add guest time in CPU meter percentage"), &(settings->accountGuestInCPUMeter)));
+   Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Align graph meter bars to reducing color blinking"), &(settings->alignGraphMeter)));
    return this;
 }

--- a/Meter.h
+++ b/Meter.h
@@ -57,6 +57,7 @@ typedef struct MeterClass_ {
 #define Meter_defaultMode(this_)       As_Meter(this_)->defaultMode
 #define Meter_getItems(this_)          As_Meter(this_)->curItems
 #define Meter_setItems(this_, n_)      As_Meter(this_)->curItems = (n_)
+#define Meter_getMaxItems(this_)       As_Meter(this_)->maxItems
 #define Meter_attributes(this_)        As_Meter(this_)->attributes
 #define Meter_name(this_)              As_Meter(this_)->name
 #define Meter_uiName(this_)            As_Meter(this_)->uiName
@@ -93,6 +94,9 @@ typedef enum {
 typedef struct GraphData_ {
    struct timeval time;
    double values[METER_BUFFER_LEN];
+   int colors[METER_BUFFER_LEN][GRAPH_HEIGHT];
+   double *valuesBuf1;
+   double *valuesBuf2;
 } GraphData;
 
 

--- a/Meter.h
+++ b/Meter.h
@@ -93,6 +93,7 @@ typedef enum {
 
 typedef struct GraphData_ {
    struct timeval time;
+   int offset;
    double values[METER_BUFFER_LEN];
    int colors[METER_BUFFER_LEN][GRAPH_HEIGHT];
    double *valuesBuf1;

--- a/Settings.c
+++ b/Settings.c
@@ -58,6 +58,7 @@ typedef struct Settings_ {
    bool updateProcessNames;
    bool accountGuestInCPUMeter;
    bool headerMargin;
+   bool alignGraphMeter;
 
    bool changed;
 } Settings;
@@ -223,6 +224,8 @@ static bool Settings_read(Settings* this, const char* fileName) {
          this->updateProcessNames = atoi(option[1]);
       } else if (String_eq(option[0], "account_guest_in_cpu_meter")) {
          this->accountGuestInCPUMeter = atoi(option[1]);
+      } else if (String_eq(option[0], "align_graph_meter")) {
+         this->alignGraphMeter = atoi(option[1]);
       } else if (String_eq(option[0], "delay")) {
          this->delay = atoi(option[1]);
       } else if (String_eq(option[0], "color_scheme")) {
@@ -304,6 +307,7 @@ bool Settings_write(Settings* this) {
    fprintf(fd, "cpu_count_from_zero=%d\n", (int) this->countCPUsFromZero);
    fprintf(fd, "update_process_names=%d\n", (int) this->updateProcessNames);
    fprintf(fd, "account_guest_in_cpu_meter=%d\n", (int) this->accountGuestInCPUMeter);
+   fprintf(fd, "align_graph_meter=%d\n", (int) this->alignGraphMeter);
    fprintf(fd, "color_scheme=%d\n", (int) this->colorScheme);
    fprintf(fd, "delay=%d\n", (int) this->delay);
    fprintf(fd, "left_meters="); writeMeters(this, fd, 0);
@@ -334,6 +338,7 @@ Settings* Settings_new(int cpuCount) {
    this->cpuCount = cpuCount;
    this->showProgramPath = true;
    this->highlightThreads = true;
+   this->alignGraphMeter = true;
    
    this->fields = xCalloc(Platform_numberOfFields+1, sizeof(ProcessField));
    // TODO: turn 'fields' into a Vector,

--- a/Settings.h
+++ b/Settings.h
@@ -49,6 +49,7 @@ typedef struct Settings_ {
    bool updateProcessNames;
    bool accountGuestInCPUMeter;
    bool headerMargin;
+   bool alignGraphMeter;
 
    bool changed;
 } Settings;


### PR DESCRIPTION
UPDATE: I'm closing this pull request because of #487. And I'm not willing to maintain this graph-color-new branch for now.
At least one issue is known in this branch:
* The graph coloring (specifically, the area calculation) will go slightly wrong when a meter's "total" value changes. The algorithm does not track the changes of this variable. As a real world example, think of when user changes the swap size (via swapon/swapoff) when a htop process is running. This issue is addressed in #487.

--------

I will close pull request #327 because of this new one. :)

![screenshot from 2015-12-24 17 35 01](https://cloud.githubusercontent.com/assets/2487263/11992796/0a438fc2-aa65-11e5-8535-a6b9c527a817.png)