### PR TITLE
Add xmalloc support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@ BatteryMeter.c Process.c ProcessList.c RichString.c ScreenManager.c Settings.c \
 SignalsPanel.c StringUtils.c SwapMeter.c TasksMeter.c UptimeMeter.c \
 TraceScreen.c UsersTable.c Vector.c AvailableColumnsPanel.c AffinityPanel.c \
 HostnameMeter.c OpenFilesScreen.c Affinity.c IncSet.c Action.c EnvScreen.c \
-InfoScreen.c
+InfoScreen.c XMalloc.c
 
 myhtopheaders = AvailableColumnsPanel.h AvailableMetersPanel.h \
 CategoriesPanel.h CheckItem.h ClockMeter.h ColorsPanel.h ColumnsPanel.h \
@@ -34,7 +34,7 @@ BatteryMeter.h Meter.h MetersPanel.h Object.h Panel.h ProcessList.h RichString.h
 ScreenManager.h Settings.h SignalsPanel.h StringUtils.h SwapMeter.h \
 TasksMeter.h UptimeMeter.h TraceScreen.h UsersTable.h Vector.h Process.h \
 AffinityPanel.h HostnameMeter.h OpenFilesScreen.h Affinity.h IncSet.h Action.h \
-EnvScreen.h InfoScreen.h
+EnvScreen.h InfoScreen.h XMalloc.h
 
 if HTOP_LINUX
 htop_CFLAGS += -rdynamic 

--- a/XMalloc.c
+++ b/XMalloc.c
@@ -1,0 +1,64 @@
+/* $OpenBSD: xmalloc.c,v 1.32 2015/04/24 01:36:01 deraadt Exp $ */
+/*
+ * Author: Tatu Ylonen <ylo@cs.hut.fi>
+ * Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
+ *                    All rights reserved
+ * Versions of malloc and friends that check their results, and never return
+ * failure (they call fatal if they encounter an error).
+ *
+ * As far as I am concerned, the code I have written for this software
+ * can be used freely for any purpose.  Any derived versions of this
+ * software must be clearly marked as such, and if the derived work is
+ * incompatible with the protocol description in the RFC file, it must be
+ * called by a name other than "ssh" or "Secure Shell".
+ */
+
+#include "XMalloc.h"
+
+#include <err.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/*{
+#include <unistd.h>
+}*/
+
+void* xmalloc(size_t size) {
+
+	void *ptr;
+
+	if (size == 0)
+		errx(1, "xmalloc: zero size");
+	ptr = malloc(size);
+	if (ptr == NULL)
+		errx(1, "xmalloc: out of memory (allocating %zu bytes)", size);
+	return ptr;
+}
+
+void* xcalloc(size_t nmemb, size_t size) {
+
+	void *ptr;
+
+	if (size == 0 || nmemb == 0)
+		errx(1, "xcalloc: zero size");
+	if (SIZE_MAX / nmemb < size)
+		errx(1, "xcalloc: nmemb * size > SIZE_MAX");
+	ptr = calloc(nmemb, size);
+	if (ptr == NULL)
+		errx(1, "xcalloc: out of memory (allocating %zu bytes)",
+		    size * nmemb);
+	return ptr;
+}
+
+void* xstrdup(const char *str) {
+
+	char *cp;
+
+	cp = strdup(str);
+	if (cp == NULL)
+		errx(1, "xstrdup: out of memory");
+	return cp;
+}


### PR DESCRIPTION
I took xmalloc.c and xmalloc.h from OpenSSH Portable and modified them
as needed. The coding style is different from htop's, but I'd suggest
keeping local modification to minimum to make merging easier.

We still need to decide whether we're going to add second variants to
call CRT_fatalError() instead of errx(). This would allow us to exit on
error without corrupting the terminal.

However, most allocations in htop assume success and crash on failure.
Using xmalloc et al. in these cases is an unambiguous improvement.