### PR TITLE
Add FreeBSD battery support

### DIFF
--- a/freebsd/Battery.c
+++ b/freebsd/Battery.c
@@ -6,10 +6,20 @@ in the source distribution for its full text.
 */
 
 #include "BatteryMeter.h"
+#include <sys/sysctl.h>
 
 void Battery_getData(double* level, ACPresence* isOnAC) {
-   // TODO
-   *level = -1;
-   *isOnAC = AC_ERROR;
-}
+   int life;
+   size_t life_len = sizeof(life);
+   if (sysctlbyname("hw.acpi.battery.life", &life, &life_len, NULL, 0) == -1)
+      *level = -1;
+   else
+      *level = life;
 
+   int acline;
+   size_t acline_len = sizeof(acline);
+   if (sysctlbyname("hw.acpi.acline", &acline, &acline_len, NULL, 0) == -1)
+      *isOnAC = AC_ERROR;
+   else
+      *isOnAC = acline == 0 ? AC_ABSENT : AC_PRESENT;
+}


### PR DESCRIPTION
Hi, thanks for htop 2.0, this is great :-)

This pull request adds support for the battery meter on FreeBSD.
Tested on both a laptop and a desktop.