### PR TITLE
Fix process memory on FreeBSD

### DIFF
--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -477,8 +477,8 @@ void ProcessList_goThroughEntries(ProcessList* this) {
       }
 
       // from FreeBSD source /src/usr.bin/top/machine.c
-      proc->m_size = kproc->ki_size / 1024;
-      proc->m_resident = kproc->ki_rssize * pageSizeKb;
+      proc->m_size = kproc->ki_size / 1024 / pageSizeKb;
+      proc->m_resident = kproc->ki_rssize;
       proc->nlwp = kproc->ki_numthreads;
       proc->time = (kproc->ki_runtime + 5000) / 10000;
 


### PR DESCRIPTION
The formulas for memory weren't correct, everything was reported 4x as large :D

See screenshot:
![htop](https://cloud.githubusercontent.com/assets/208340/12976881/129815e6-d0d8-11e5-9500-986631256f6e.png)