### PR TITLE
Add a 'kill process group' feature bound to the 'g' key

### DIFF
--- a/Action.h
+++ b/Action.h
@@ -52,5 +52,4 @@ Htop_Reaction Action_setSortKey(Settings* settings, ProcessField sortKey);
 
 void Action_setBindings(Htop_Action* keys);
 
-
 #endif

--- a/Process.c
+++ b/Process.c
@@ -536,6 +536,10 @@ void Process_sendSignal(Process* this, size_t sgn) {
    seteuid(euid);
 }
 
+void Process_sendGroupSignal(Process* this, size_t sgn) {
+   kill(-this->pgrp, (int) sgn);
+}
+
 long Process_pidCompare(const void* v1, const void* v2) {
    Process* p1 = (Process*)v1;
    Process* p2 = (Process*)v2;

--- a/Process.h
+++ b/Process.h
@@ -189,6 +189,8 @@ bool Process_changePriorityBy(Process* this, size_t delta);
 
 void Process_sendSignal(Process* this, size_t sgn);
 
+void Process_sendGroupSignal(Process* this, size_t sgn);
+
 long Process_pidCompare(const void* v1, const void* v2);
 
 long Process_compare(const void* v1, const void* v2);

--- a/README
+++ b/README
@@ -30,7 +30,7 @@ Comparison between 'htop' and classic 'top'
   kill a process, in 'top' you do.
 * In 'htop' you don't need to type the process number or
   the priority value to renice a process, in 'top' you do.
-* In 'htop' you can kill multiple processes at once.
+* In 'htop' you can kill multiple processes or process groups at once.
 * 'top' is older, hence, more tested.
 
 Compilation instructions

--- a/htop.1.in
+++ b/htop.1.in
@@ -110,6 +110,12 @@ Decrease the selected process's priority (add to 'nice' value)
 of processes. If processes were tagged, sends the signal to all tagged processes.
 If none is tagged, sends to the currently selected process.
 .TP
+.B g
+"Kill" whole process group: sends a signal which is selected in a menu, to one or
+a group of process groups. If processes were tagged, sends the signal to all
+tagged processes' groups.
+If none is tagged, sends to the currently selected process' group.
+.TP
 .B F10, q
 Quit
 .TP


### PR DESCRIPTION
_(Opening a new issue to replace the former #122 which looks buggy for some reason, but the content is exactly the same.)_

Hello,

This PR adds the “kill group” feature bound to the “g” key. It works exactly as the “kill” feature (F9/k), except that it kills all processes sharing the same PGRP instead of a single process.

Best regards,
