### PR TITLE
Fix implicit define isnan()

### DIFF
--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -24,6 +24,7 @@ in the source distribution for its full text.
 #include <sys/resource.h>
 #include <vm/vm_param.h>
 #include <time.h>
+#include <math.h>
 
 /*{
 #include "Action.h"


### PR DESCRIPTION
```
freebsd/Platform.c:179:8: warning: implicit declaration of function 'isnan' is invalid in C99 [-Wimplicit-function-declaration]
   if (isnan(percent)) percent = 0.0;
       ^
```
isnan() is defined in `<math.h>`
This trades the implicit definition warning for the warning
```
freebsd/Platform.c:180:8: warning: generic selections are a C11-specific feature [-Wc11-extensions]
   if (isnan(percent)) percent = 0.0;
       ^
/usr/include/math.h:118:2: note: expanded from macro 'isnan'
        __fp_type_select(x, __inline_isnanf, __inline_isnan, __inline_isnanl)
        ^
/usr/include/math.h:86:39: note: expanded from macro '__fp_type_select'
#define __fp_type_select(x, f, d, ld) _Generic((x),                     \
                                      ^
```
As noted in https://llvm.org/bugs/show_bug.cgi?id=17788