### PR TITLE
Show process arguments on OSX

### DIFF
--- a/darwin/DarwinProcess.c
+++ b/darwin/DarwinProcess.c
@@ -286,7 +286,7 @@ void DarwinProcess_setFromKInfoProc(Process *proc, struct kinfo_proc *ps, time_t
       /* The command is from the old Mac htop */
       char *slash;
 
-      proc->comm = DarwinProcess_getCmdLine(ps, false);
+      proc->comm = DarwinProcess_getCmdLine(ps, true);
       slash = strrchr(proc->comm, '/');
       proc->basenameOffset = (NULL != slash) ? (slash - proc->comm) : 0;
    }


### PR DESCRIPTION
Follow up to: https://github.com/hishamhm/htop/issues/379

Currently calling `DarwinProcess_getCmdLine(ps, false)` disables showing the process arguments. Is there a certain reason for this (unfinished feature, forgot to re-enable after testing)?