### PR TITLE
Fix "__NR_ioprio_set undeclared"

### DIFF
--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -13,6 +13,7 @@ in the source distribution for its full text.
 
 #include <stdlib.h>
 #include <unistd.h>
+#include <linux/unistd.h>
 #include <string.h>
 #include <sys/syscall.h>
 


### PR DESCRIPTION
In ubuntu 14.04 macro "__NR_ioprio_set" defined at file "linux/unistd.h"