### PR TITLE
Mouse-friendly functions bar for meters panel

### DIFF
--- a/MetersPanel.c
+++ b/MetersPanel.c
@@ -31,7 +31,9 @@ struct MetersPanel_ {
 
 }*/
 
-static const char* MetersFunctions[] = {"Type  ", "Move  ", "Delete", "Done  ", NULL};
+// Note: In code the meters are known to have bar/text/graph "Modes", but in UI
+// we call them "Styles".
+static const char* MetersFunctions[] = {"Style ", "Move  ", "Delete", "Done  ", NULL};
 static const char* MetersKeys[] = {"Space", "Enter", "Del", "Esc"};
 static int MetersEvents[] = {' ', 13, KEY_DC, 27};
 

--- a/MetersPanel.c
+++ b/MetersPanel.c
@@ -33,13 +33,17 @@ struct MetersPanel_ {
 
 // Note: In code the meters are known to have bar/text/graph "Modes", but in UI
 // we call them "Styles".
-static const char* MetersFunctions[] = {"Style ", "Move  ", "Delete", "Done  ", NULL};
-static const char* MetersKeys[] = {"Space", "Enter", "Del", "Esc"};
-static int MetersEvents[] = {' ', 13, KEY_DC, 27};
+static const char* MetersFunctions[] = {"Style ", "Move  ", "                                       ", "Delete", "Done  ", NULL};
+static const char* MetersKeys[] = {"Space", "Enter", "  ", "Del", "F10"};
+static int MetersEvents[] = {' ', 13, ERR, KEY_DC, KEY_F(10)};
 
-static const char* MetersMovingFunctions[] = {"Up    ", "Down  ", "Left  ", "Right ",  "Confirm", "Delete", "Done  ", NULL};
-static const char* MetersMovingKeys[] = {"Up", "Dn", "Lt", "Rt", "Enter", "Del", "Esc"};
-static int MetersMovingEvents[] = {KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT, 13, KEY_DC, 27};
+// We avoid UTF-8 arrows ← → here as they might display full-width on Chinese
+// terminals, breaking our aligning.
+// In <http://unicode.org/reports/tr11/>, arrows (U+2019..U+2199) are
+// considered "Ambiguous characters".
+static const char* MetersMovingFunctions[] = {"Style ", "Lock  ", "Up    ", "Down  ", "Left  ", "Right ", "       ", "Delete", "Done  ", NULL};
+static const char* MetersMovingKeys[] = {"Space", "Enter", "Up", "Dn", "<-", "->", "  ", "Del", "F10"};
+static int MetersMovingEvents[] = {' ', 13, KEY_UP, KEY_DOWN, KEY_LEFT, KEY_RIGHT, ERR, KEY_DC, KEY_F(10)};
 static FunctionBar* Meters_movingBar = NULL;
 
 static void MetersPanel_delete(Object* object) {

--- a/MetersPanel.h
+++ b/MetersPanel.h
@@ -27,6 +27,8 @@ struct MetersPanel_ {
 };
 
 
+// Note: In code the meters are known to have bar/text/graph "Modes", but in UI
+// we call them "Styles".
 
 void MetersPanel_setMoving(MetersPanel* this, bool moving);
 

--- a/MetersPanel.h
+++ b/MetersPanel.h
@@ -29,6 +29,10 @@ struct MetersPanel_ {
 
 // Note: In code the meters are known to have bar/text/graph "Modes", but in UI
 // we call them "Styles".
+// We avoid UTF-8 arrows ← → here as they might display full-width on Chinese
+// terminals, breaking our aligning.
+// In <http://unicode.org/reports/tr11/>, arrows (U+2019..U+2199) are
+// considered "Ambiguous characters".
 
 void MetersPanel_setMoving(MetersPanel* this, bool moving);
 


### PR DESCRIPTION
![selection_215](https://cloud.githubusercontent.com/assets/2487263/13098490/d88e0d10-d564-11e5-82a0-1ccf41ef5d84.png)

Before:

```
SpaceType  EnterMove  DelDeleteEscDone  |
~~~~~      ~~~~~      ~~~      ~~~      |
UpUp     DnDown  LtLeft  RtRight EnterConfirmDelDeleteEscDone  |
~~       ~~      ~~      ~~      ~~~~~       ~~~      ~~~      |
```

After:

```
SpaceType  EnterMove                                           DelDeleteF10Done  |
~~~~~      ~~~~~      ~~                                       ~~~      ~~~      |
SpaceType  EnterLock  UpUp    DnDown  <-Left  ->Right          DelDeleteF10Done  |
~~~~~      ~~~~~      ~~      ~~      ~~      ~~      ~~       ~~~      ~~~      |
```
- Align 'Delete' and 'Done' to the right to match functions on other screens.
  (Accidental clicking is avoided as a side benefit.)
- You could change meter type while in moving mode. New bar now hints this.
- Two Enter key functions are put in the same place and so mouse clicks there
  act like functions toggle. (The wording change to 'Lock' is also to reflect
  this.)
- '<-' and '->' instead of 'Lt' and 'Rt' abbreviation as the latter is not
  widely seen and arrows shapes are obvious. :)
- I'm advocating to avoid mentioning 'Esc' key anywhere in functions bar now,
  because for ncurses apps, Esc key does not take effect immediately, but
  rather in a couple seconds. Double 'Esc' presses does take it immediately,
  but new users unfamiliar with ncurses will not notice it. So here, 'F10',
  which takes effect immediately, is better.
