### PR TITLE
quit when receive EOT (Ctrl+D)

### DIFF
--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -301,6 +301,7 @@ void ScreenManager_run(ScreenManager* this, Panel** lastFocus, int* lastKey) {
          if (Panel_size(panelFocus) == 0 && focus < this->panelCount - 1)
             goto tryRight;
          break;
+      case 4:
       case KEY_F(10):
       case 'q':
       case 27:


### PR DESCRIPTION
Simple line of code, that allows htop exit when EOT (Ctrl+D) is pressed.