### PR TITLE
Misc. OpenBSD tuneup and improvement

### DIFF
--- a/openbsd/OpenBSDProcessList.h
+++ b/openbsd/OpenBSDProcessList.h
@@ -27,10 +27,20 @@ typedef struct OpenBSDProcessList_ {
 } OpenBSDProcessList;
 
 
-#ifndef CLAMP
-#define CLAMP(x,low,high) (((x)>(high))?(high):(((x)<(low))?(low):(x)))
+/*
+ * avoid relying on or conflicting with MIN() and MAX() in sys/param.h
+ */
+#ifndef MINIMUM
+#define MINIMUM(x, y)		((x) > (y) ? (y) : (x))
 #endif
 
+#ifndef MAXIMUM
+#define MAXIMUM(x, y)		((x) > (y) ? (x) : (y))
+#endif
+
+#ifndef CLAMP
+#define CLAMP(x, low, high)	(((x) > (high)) ? (high) : MAXIMUM(x, low))
+#endif
 
 ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, uid_t userId);
 


### PR DESCRIPTION
Including:

 o set *basenameEnd even in error cases (FreeBSD probably needs this)

 o use kvm_openfiles(3) rather than kvm_open(3) so that we can report
   errors (as with FreeBSD)

 o sanify the process argument list creation by using strlcat(3)

 o drop the pageSizeKb variable and use the PAGE_SIZE_KB macro directly,
   as the page size can't change anyway

 o clean up a few macros, add MINIMUM() and MAXIMUM() (should be
   mirrored to FreeBSD)

 o fix some syntax

 o add some useful comments