### PR TITLE
Avoid overlapping key values defined by curses (Real fix).

### DIFF
--- a/CRT.c
+++ b/CRT.c
@@ -125,7 +125,7 @@ void CRT_fatalError(const char* note) __attribute__ ((noreturn));
 
 void CRT_handleSIGSEGV(int sgn);
 
-#define KEY_ALT(x) KEY_F(64) + (x - 'A')
+#define KEY_ALT(x) (KEY_F(64 - 26) + (x - 'A'))
 
 }*/
 

--- a/CRT.h
+++ b/CRT.h
@@ -115,7 +115,7 @@ void CRT_fatalError(const char* note) __attribute__ ((noreturn));
 
 void CRT_handleSIGSEGV(int sgn);
 
-#define KEY_ALT(x) KEY_F(64) + (x - 'A')
+#define KEY_ALT(x) (KEY_F(64 - 26) + (x - 'A'))
 
 
 extern const char *CRT_treeStrAscii[TREE_STR_COUNT];


### PR DESCRIPTION
Real fix for issue #438.