### PR TITLE
Replace platform-specific PID_MAX code with sizeof(pid_t)

### DIFF
--- a/Process.h
+++ b/Process.h
@@ -138,7 +138,7 @@ void Process_delete(Object* cast);
 bool Process_isThread(Process* this);
 extern ProcessFieldData Process_fields[];
 extern ProcessPidColumn Process_pidColumns[];
-extern char Process_pidFormat[20];
+extern char Process_pidFormat[21];
 
 typedef Process*(*Process_New)(struct Settings_*);
 typedef void (*Process_WriteField)(Process*, RichString*, ProcessField);
@@ -159,7 +159,7 @@ typedef struct ProcessClass_ {
 #define ONE_DECIMAL_M (ONE_DECIMAL_K * ONE_DECIMAL_K)
 #define ONE_DECIMAL_G (ONE_DECIMAL_M * ONE_DECIMAL_K)
 
-extern char Process_pidFormat[20];
+extern char Process_pidFormat[21];
 
 void Process_setupColumnWidths();
 

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -155,11 +155,6 @@ void Platform_getLoadAverage(double* one, double* five, double* fifteen) {
    }
 }
 
-int Platform_getMaxPid() {
-   /* http://opensource.apple.com/source/xnu/xnu-2782.1.97/bsd/sys/proc_internal.hh */
-   return 99999;
-}
-
 ProcessPidColumn Process_pidColumns[] = {
    { .id = PID, .label = "PID" },
    { .id = PPID, .label = "PPID" },

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -38,8 +38,6 @@ int Platform_getUptime();
 
 void Platform_getLoadAverage(double* one, double* five, double* fifteen);
 
-int Platform_getMaxPid();
-
 extern ProcessPidColumn Process_pidColumns[];
 
 double Platform_setCPUValues(Meter* mtr, int cpu);

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -138,16 +138,6 @@ void Platform_getLoadAverage(double* one, double* five, double* fifteen) {
    *fifteen = (double) loadAverage.ldavg[2] / loadAverage.fscale;
 }
 
-int Platform_getMaxPid() {
-   int maxPid;
-   size_t size = sizeof(maxPid);
-   int err = sysctlbyname("kern.pid_max", &maxPid, &size, NULL, 0);
-   if (err) {
-      return 99999;
-   }
-   return maxPid;
-}
-
 double Platform_setCPUValues(Meter* this, int cpu) {
    FreeBSDProcessList* fpl = (FreeBSDProcessList*) this->pl;
    int cpus = this->pl->cpuCount;

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -36,8 +36,6 @@ int Platform_getUptime();
 
 void Platform_getLoadAverage(double* one, double* five, double* fifteen);
 
-int Platform_getMaxPid();
-
 double Platform_setCPUValues(Meter* this, int cpu);
 
 void Platform_setMemoryValues(Meter* this);

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -153,16 +153,6 @@ void Platform_getLoadAverage(double* one, double* five, double* fifteen) {
    }
 }
 
-int Platform_getMaxPid() {
-   FILE* file = fopen(PROCDIR "/sys/kernel/pid_max", "r");
-   if (!file) return -1;
-   int maxPid = 4194303;
-   int match = fscanf(file, "%32d", &maxPid);
-   (void) match;
-   fclose(file);
-   return maxPid;
-}
-
 double Platform_setCPUValues(Meter* this, int cpu) {
    LinuxProcessList* pl = (LinuxProcessList*) this->pl;
    CPUData* cpuData = &(pl->cpus[cpu]);

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -35,8 +35,6 @@ int Platform_getUptime();
 
 void Platform_getLoadAverage(double* one, double* five, double* fifteen);
 
-int Platform_getMaxPid();
-
 double Platform_setCPUValues(Meter* this, int cpu);
 
 void Platform_setMemoryValues(Meter* this);

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -195,11 +195,6 @@ void Platform_getLoadAverage(double* one, double* five, double* fifteen) {
    *fifteen = (double) loadAverage.ldavg[2] / loadAverage.fscale;
 }
 
-int Platform_getMaxPid() {
-   // this is hard-coded in sys/sys/proc.h - no sysctl exists
-   return 32766;
-}
-
 double Platform_setCPUValues(Meter* this, int cpu) {
    int i;
    double perc;

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -52,8 +52,6 @@ int Platform_getUptime();
 
 void Platform_getLoadAverage(double* one, double* five, double* fifteen);
 
-int Platform_getMaxPid();
-
 double Platform_setCPUValues(Meter* this, int cpu);
 
 void Platform_setMemoryValues(Meter* this);

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -87,7 +87,7 @@ void Platform_setBindings(Htop_Action* keys) {
 
 int Platform_numberOfFields = 100;
 
-extern char Process_pidFormat[20];
+extern char Process_pidFormat[21];
 
 ProcessPidColumn Process_pidColumns[] = {
    { .id = 0, .label = NULL },
@@ -101,10 +101,6 @@ void Platform_getLoadAverage(double* one, double* five, double* fifteen) {
    *one = 0;
    *five = 0;
    *fifteen = 0;
-}
-
-int Platform_getMaxPid() {
-   return 1;
 }
 
 double Platform_setCPUValues(Meter* this, int cpu) {

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -29,15 +29,13 @@ void Platform_setBindings(Htop_Action* keys);
 
 extern int Platform_numberOfFields;
 
-extern char Process_pidFormat[20];
+extern char Process_pidFormat[21];
 
 extern ProcessPidColumn Process_pidColumns[];
 
 int Platform_getUptime();
 
 void Platform_getLoadAverage(double* one, double* five, double* fifteen);
-
-int Platform_getMaxPid();
 
 double Platform_setCPUValues(Meter* this, int cpu);
 


### PR DESCRIPTION
It seems easier to use sizeof(pid_t) instead of platform-specific code
with magic numbers. PID_MAX generally isn't exposed to userland by
sys/proc.h, so porters have to manually copy the number over and are
unlikely to update if it changes.

It seems that it costs us a few characters worth of screen space,
though. Hisham will decide whether it's worth the simplification. I
highly doubt that any platform has pid_t larger than 32 bits, so this is
unlikely to waste more than ~5 characters.

For what it's worth, POSIX tells us that pid_t is:

 o signed
 o no larger than long