### PR TITLE
BarMeterMode_draw() minor code improvement

### DIFF
--- a/Meter.c
+++ b/Meter.c
@@ -287,11 +287,8 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
    char bar[w + 1];
    
    int blockSizes[10];
-   for (int i = 0; i < w; i++)
-      bar[i] = ' ';
 
-   const size_t barOffset = w - MIN((int)strlen(buffer), w);
-   snprintf(bar + barOffset, w - barOffset + 1, "%s", buffer);
+   snprintf(bar, w + 1, "%*s", w, buffer);
 
    // First draw in the bar[] buffer...
    int offset = 0;


### PR DESCRIPTION
Removed a loop that sets the bar[] buffer with spaces and merged that
task to the snprintf() call just below. No need for the barOffset
variable. Display behavior is unchanged.

Size comparision (when compiled on Ubuntu 14.04 64-bit):

    $ size htop.old htop.new
       text    data     bss     dec     hex filename
     137312   15112    3776  156200   26228 htop.old
     137216   15112    3776  156104   261c8 htop.new