### PR TITLE
Add support of UUID CTID used in the new version of OpenVZ

### DIFF
--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -114,7 +114,7 @@ typedef struct LinuxProcess_ {
    double io_rate_write_bps;
    #endif
    #ifdef HAVE_OPENVZ
-   unsigned int ctid;
+   char* ctid;
    unsigned int vpid;
    #endif
    #ifdef HAVE_VSERVER
@@ -251,6 +251,9 @@ LinuxProcess* LinuxProcess_new(Settings* settings) {
 void Process_delete(Object* cast) {
    LinuxProcess* this = (LinuxProcess*) cast;
    Process_done((Process*)cast);
+#ifdef HAVE_OPENVZ
+   free(this->ctid);
+#endif
 #ifdef HAVE_CGROUP
    free(this->cgroup);
 #endif
@@ -321,7 +324,7 @@ void LinuxProcess_writeField(Process* this, RichString* str, ProcessField field)
    }
    #endif
    #ifdef HAVE_OPENVZ
-   case CTID: snprintf(buffer, n, "%7u ", lp->ctid); break;
+   case CTID: snprintf(buffer, n, "%8.8s ", lp->ctid); break;
    case VPID: snprintf(buffer, n, Process_pidFormat, lp->vpid); break;
    #endif
    #ifdef HAVE_VSERVER
@@ -396,7 +399,7 @@ long LinuxProcess_compare(const void* v1, const void* v2) {
    #endif
    #ifdef HAVE_OPENVZ
    case CTID:
-      return (p2->ctid - p1->ctid);
+      return strcmp(p1->ctid ?: "", p2->ctid ?: "");
    case VPID:
       return (p2->vpid - p1->vpid);
    #endif

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -106,7 +106,7 @@ typedef struct LinuxProcess_ {
    double io_rate_write_bps;
    #endif
    #ifdef HAVE_OPENVZ
-   unsigned int ctid;
+   char* ctid;
    unsigned int vpid;
    #endif
    #ifdef HAVE_VSERVER


### PR DESCRIPTION
In the new version of OpenVZ (Virtuozzo 7), containers could be identified by UUIDs and integer numbers like before (so called legacy CTID). Existing support of OpenVZ can't work with UUIDs. This patch fix it.

CTIDs and VPIDs are now read from /proc/[id]/status instead of /proc/[id]/stat because of the following reasons:
- the /proc/[id]/status has named fields and OpenVZ kernel writes either CTID or UUID to envID field (depending on which type is used);
- OpenVZ kernel appends own data to /proc/[id]/stat file, a change in parameters reported by vanilla kernel would also shift the position of OpenVZ data so it would not be read correctly.

As UUIDs are much longer than old numerical CTIDs, the UUID strings will get truncated in output (although sorting is still done using complete UUIDs).
