### PR TITLE
Experimental Load Average bar

### DIFF
--- a/Meter.c
+++ b/Meter.c
@@ -13,6 +13,7 @@ in the source distribution for its full text.
 #include "StringUtils.h"
 #include "ListItem.h"
 #include "Settings.h"
+#include "ProcessList.h"
 
 #include <math.h>
 #include <string.h>
@@ -20,6 +21,8 @@ in the source distribution for its full text.
 #include <stdarg.h>
 #include <assert.h>
 #include <sys/time.h>
+
+#define HAVE_LOAD_GRAPH
 
 #define METER_BUFFER_LEN 256
 
@@ -293,6 +296,34 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
    // First draw in the bar[] buffer...
    int offset = 0;
    int items = Meter_getItems(this);
+
+#ifdef HAVE_LOAD_GRAPH
+   // Experimental Load Average bar drawing
+   // TODO: Make it into a subroutine for better encapsulation.
+   if (strcmp(As_Meter(this)->name, "Load") == 0) {
+      // ':' for number of cpu cores point
+      if (bar[w / 2] == ' ') {
+         bar[w / 2] = ':';
+      }
+      assert(Meter_getItems(this) == 1);
+      
+      blockSizes[0] = (int)round(atan2(this->values[0], this->pl->cpuCount) *
+                                 w / M_PI_2);
+      for (int j = 0; j < blockSizes[0]; j++) {
+         if (bar[j] == ' ') {
+            bar[j] = '|';
+         }
+      }
+      attrset(CRT_colors[Meter_attributes(this)[0]]);
+      mvaddnstr(y, x, bar, blockSizes[0]);
+      if (blockSizes[0] < w) {
+         attrset(CRT_colors[BAR_SHADOW]);
+         mvaddnstr(y, x + blockSizes[0], bar + blockSizes[0], w - blockSizes[0]);
+      }
+      return;
+   }
+#endif
+
    for (int i = 0; i < items; i++) {
       double value = this->values[i];
       value = CLAMP(value, 0.0, this->total);
@@ -331,6 +362,8 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
    move(y, x + w + 1);
    attrset(CRT_colors[RESET_COLOR]);
 }
+
+// [         :         ]
 
 /* ---------- GraphMeterMode ---------- */
 

--- a/Meter.c
+++ b/Meter.c
@@ -306,7 +306,10 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
          bar[w / 2] = ':';
       }
       assert(Meter_getItems(this) == 1);
-      
+
+#ifndef M_PI_2
+# define M_PI_2 atan2(1,0)
+#endif
       blockSizes[0] = (int)round(atan2(this->values[0], this->pl->cpuCount) *
                                  w / M_PI_2);
       for (int j = 0; j < blockSizes[0]; j++) {
@@ -362,8 +365,6 @@ static void BarMeterMode_draw(Meter* this, int x, int y, int w) {
    move(y, x + w + 1);
    attrset(CRT_colors[RESET_COLOR]);
 }
-
-// [         :         ]
 
 /* ---------- GraphMeterMode ---------- */
 

--- a/Meter.h
+++ b/Meter.h
@@ -9,6 +9,8 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
+#define HAVE_LOAD_GRAPH
+
 #define METER_BUFFER_LEN 256
 
 #define GRAPH_DELAY (DEFAULT_DELAY/2)
@@ -123,6 +125,8 @@ ListItem* Meter_toListItem(Meter* this, bool moving);
 /* ---------- TextMeterMode ---------- */
 
 /* ---------- BarMeterMode ---------- */
+
+// [         :         ]
 
 /* ---------- GraphMeterMode ---------- */
 


### PR DESCRIPTION
(This code is for testing only. **Do not merge.**)

An experimental bar display for load / load average meter.

![selection_224](https://cloud.githubusercontent.com/assets/2487263/14449413/4a748d26-00a5-11e6-8526-05556a853e1d.png)
![selection_225](https://cloud.githubusercontent.com/assets/2487263/14449414/4c4cd8ec-00a5-11e6-84a8-fe6ad18332f4.png)
![loadavg](https://cloud.githubusercontent.com/assets/2487263/14449420/5f46cf20-00a5-11e6-9a84-5e46f76855a4.png)

The scale on the picture is deliberately chosen to be non-linear, in order to address the infinite maximum of the load average values. This is called "arctangent" scale. I can rework it to use linear scale if people finds this "arctangent" scale confusing.
