### PR TITLE
Use Linux backend on the Hurd

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -26,17 +26,17 @@ AC_PROG_LIBTOOL
 
 # Checks for platform.
 # ----------------------------------------------------------------------
-case "$target" in
-*linux*)
+case "$target_os" in
+linux*)
    my_htop_platform=linux
    ;;
-*freebsd*)
+freebsd*|kfreebsd*)
    my_htop_platform=freebsd
    ;;
-*openbsd*)
+openbsd*)
    my_htop_platform=openbsd
    ;;
-*darwin*)
+darwin*)
    my_htop_platform=darwin
    ;;
 *)

--- a/configure.ac
+++ b/configure.ac
@@ -27,7 +27,7 @@ AC_PROG_LIBTOOL
 # Checks for platform.
 # ----------------------------------------------------------------------
 case "$target_os" in
-linux*)
+linux*|gnu*)
    my_htop_platform=linux
    ;;
 freebsd*|kfreebsd*)


### PR DESCRIPTION
The first commit to use target_os is because `*gnu*` would match platforms other than the Hurd (such as GNU/kFreeBSD, which is i386-kfreebsd-gnu), although even without that I would argue that it's the correct variable to be using in this instance. The Hurd provides a good enough /proc filesystem for the Linux backend, and past versions (pre-v2) worked unmodified.