### PR TITLE
Fix a typo in the man page (Debian Lintian spelling-error-in-manpage)

### DIFF
--- a/htop.1.in
+++ b/htop.1.in
@@ -10,7 +10,7 @@ Htop is a free (GPL) ncurses-based process viewer for Linux.
 .LP
 It is similar to top, but allows you to scroll vertically and horizontally,
 so you can see all the processes running on the system, along with their full
-command lines, as well as viewing them as a process tree, selecting mutiple
+command lines, as well as viewing them as a process tree, selecting multiple
 processes and acting on them all at once.
 .LP
 Tasks related to processes (killing, renicing) can be done without


### PR DESCRIPTION
Debian patch from
https://anonscm.debian.org/cgit/collab-maint/htop.git/tree/debian/patches/001-lintian-warning-fix-man-typo.patch