### PR TITLE
Add Keywords entry to .desktop file (Debian Lintian warning desktop-e…

### DIFF
--- a/htop.desktop
+++ b/htop.desktop
@@ -60,3 +60,4 @@ GenericName[sv]=Processvisning
 GenericName[tr]=Süreç Görüntüleyici
 GenericName[uk]=Перегляд процесів
 GenericName[zh_TW]=行程檢視器
+Keywords=system;process;task


### PR DESCRIPTION
…ntry-lacks-keywords-entry)

Debian patch from
https://anonscm.debian.org/cgit/collab-maint/htop.git/tree/debian/patches/002-lintian-warning-fix-desktop-keywords.patch