### PR TITLE
Use SOURCE_DATE_EPOCH instead of current year in copyright message to…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,7 @@
 AC_PREREQ(2.65)
 AC_INIT([htop],[2.0.1],[hisham@gobolinux.org])
 
-year=$(date +%Y)
+year=$(date --utc --date="@${SOURCE_DATE_EPOCH:-$(date +%s)}" +%Y)
 
 # The following two lines are required by hwloc scripts
 AC_USE_SYSTEM_EXTENSIONS


### PR DESCRIPTION
… make build reproducible

Debian patch from
https://anonscm.debian.org/cgit/collab-maint/htop.git/tree/debian/patches/003-use-source-date-epoch.patch
by Graham Inggs