### PR TITLE
Remove needless allocation error conditions

### DIFF
--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -280,11 +280,9 @@ char* Platform_getProcessEnv(pid_t pid) {
 
                size_t size = endp - p;
                env = xMalloc(size+2);
-               if (env) {
-                  memcpy(env, p, size);
-                  env[size] = 0;
-                  env[size+1] = 0;
-               }
+               memcpy(env, p, size);
+               env[size] = 0;
+               env[size+1] = 0;
             }
          }
          free(buf);

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -265,9 +265,6 @@ void Platform_setSwapValues(Meter* this) {
    }
 
    swdev = xCalloc(nswap, sizeof(*swdev));
-   if (swdev == NULL) {
-      return;
-   }
 
    rnswap = swapctl(SWAP_STATS, swdev, nswap);
    if (rnswap == -1) {


### PR DESCRIPTION
These allocations were converted to use xMalloc et al. and no longer
need error checks.