### PR TITLE
Rename Meter.setValues() functions to updateValues()

### DIFF
--- a/BatteryMeter.c
+++ b/BatteryMeter.c
@@ -32,7 +32,7 @@ int BatteryMeter_attributes[] = {
    BATTERY
 };
 
-static void BatteryMeter_setValues(Meter * this, char *buffer, int len) {
+static void BatteryMeter_updateValues(Meter * this, char *buffer, int len) {
    ACPresence isOnAC;
    double percent;
    
@@ -73,7 +73,7 @@ MeterClass BatteryMeter_class = {
       .extends = Class(Meter),
       .delete = Meter_delete
    },
-   .setValues = BatteryMeter_setValues,
+   .updateValues = BatteryMeter_updateValues,
    .defaultMode = TEXT_METERMODE,
    .maxItems = 1,
    .total = 100.0,

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -55,7 +55,7 @@ static void CPUMeter_init(Meter* this) {
       Meter_setCaption(this, "Avg");
 }
 
-static void CPUMeter_setValues(Meter* this, char* buffer, int size) {
+static void CPUMeter_updateValues(Meter* this, char* buffer, int size) {
    int cpu = this->param;
    if (cpu > this->pl->cpuCount) {
       snprintf(buffer, size, "absent");
@@ -215,7 +215,7 @@ MeterClass CPUMeter_class = {
       .delete = Meter_delete,
       .display = CPUMeter_display
    },
-   .setValues = CPUMeter_setValues, 
+   .updateValues = CPUMeter_updateValues,
    .defaultMode = BAR_METERMODE,
    .maxItems = CPU_METER_ITEMCOUNT,
    .total = 100.0,

--- a/ClockMeter.c
+++ b/ClockMeter.c
@@ -19,7 +19,7 @@ int ClockMeter_attributes[] = {
    CLOCK
 };
 
-static void ClockMeter_setValues(Meter* this, char* buffer, int size) {
+static void ClockMeter_updateValues(Meter* this, char* buffer, int size) {
    time_t t = time(NULL);
    struct tm result;
    struct tm *lt = localtime_r(&t, &result);
@@ -32,7 +32,7 @@ MeterClass ClockMeter_class = {
       .extends = Class(Meter),
       .delete = Meter_delete
    },
-   .setValues = ClockMeter_setValues, 
+   .updateValues = ClockMeter_updateValues,
    .defaultMode = TEXT_METERMODE,
    .maxItems = 1,
    .total = 1440, /* 24*60 */

--- a/HostnameMeter.c
+++ b/HostnameMeter.c
@@ -19,7 +19,7 @@ int HostnameMeter_attributes[] = {
    HOSTNAME
 };
 
-static void HostnameMeter_setValues(Meter* this, char* buffer, int size) {
+static void HostnameMeter_updateValues(Meter* this, char* buffer, int size) {
    (void) this;
    gethostname(buffer, size-1);
 }
@@ -29,7 +29,7 @@ MeterClass HostnameMeter_class = {
       .extends = Class(Meter),
       .delete = Meter_delete
    },
-   .setValues = HostnameMeter_setValues, 
+   .updateValues = HostnameMeter_updateValues,
    .defaultMode = TEXT_METERMODE,
    .maxItems = 0,
    .total = 100.0,

--- a/LoadAverageMeter.c
+++ b/LoadAverageMeter.c
@@ -20,7 +20,7 @@ int LoadAverageMeter_attributes[] = {
 
 int LoadMeter_attributes[] = { LOAD };
 
-static void LoadAverageMeter_setValues(Meter* this, char* buffer, int size) {
+static void LoadAverageMeter_updateValues(Meter* this, char* buffer, int size) {
    Platform_getLoadAverage(&this->values[0], &this->values[1], &this->values[2]);
    snprintf(buffer, size, "%.2f/%.2f/%.2f", this->values[0], this->values[1], this->values[2]);
 }
@@ -36,7 +36,7 @@ static void LoadAverageMeter_display(Object* cast, RichString* out) {
    RichString_append(out, CRT_colors[LOAD_AVERAGE_FIFTEEN], buffer);
 }
 
-static void LoadMeter_setValues(Meter* this, char* buffer, int size) {
+static void LoadMeter_updateValues(Meter* this, char* buffer, int size) {
    double five, fifteen;
    Platform_getLoadAverage(&this->values[0], &five, &fifteen);
    if (this->values[0] > this->total) {
@@ -58,7 +58,7 @@ MeterClass LoadAverageMeter_class = {
       .delete = Meter_delete,
       .display = LoadAverageMeter_display,
    },
-   .setValues = LoadAverageMeter_setValues, 
+   .updateValues = LoadAverageMeter_updateValues,
    .defaultMode = TEXT_METERMODE,
    .maxItems = 3,
    .total = 100.0,
@@ -75,7 +75,7 @@ MeterClass LoadMeter_class = {
       .delete = Meter_delete,
       .display = LoadMeter_display,
    },
-   .setValues = LoadMeter_setValues, 
+   .updateValues = LoadMeter_updateValues,
    .defaultMode = TEXT_METERMODE,
    .maxItems = 1,
    .total = 100.0,

--- a/MemoryMeter.c
+++ b/MemoryMeter.c
@@ -24,7 +24,7 @@ int MemoryMeter_attributes[] = {
    MEMORY_USED, MEMORY_BUFFERS, MEMORY_CACHE
 };
 
-static void MemoryMeter_setValues(Meter* this, char* buffer, int size) {
+static void MemoryMeter_updateValues(Meter* this, char* buffer, int size) {
    int written;
    Platform_setMemoryValues(this);
 
@@ -60,7 +60,7 @@ MeterClass MemoryMeter_class = {
       .delete = Meter_delete,
       .display = MemoryMeter_display,
    },
-   .setValues = MemoryMeter_setValues, 
+   .updateValues = MemoryMeter_updateValues, 
    .defaultMode = BAR_METERMODE,
    .maxItems = 3,
    .total = 100.0,

--- a/Meter.h
+++ b/Meter.h
@@ -24,7 +24,7 @@ typedef struct Meter_ Meter;
 typedef void(*Meter_Init)(Meter*);
 typedef void(*Meter_Done)(Meter*);
 typedef void(*Meter_UpdateMode)(Meter*, int);
-typedef void(*Meter_SetValues)(Meter*, char*, int);
+typedef void(*Meter_UpdateValues)(Meter*, char*, int);
 typedef void(*Meter_Draw)(Meter*, int, int, int);
 
 typedef struct MeterClass_ {
@@ -33,7 +33,7 @@ typedef struct MeterClass_ {
    const Meter_Done done;
    const Meter_UpdateMode updateMode;
    const Meter_Draw draw;
-   const Meter_SetValues setValues;
+   const Meter_UpdateValues updateValues;
    const int defaultMode;
    const double total;
    const int* attributes;
@@ -53,7 +53,8 @@ typedef struct MeterClass_ {
 #define Meter_updateMode(this_, m_)    As_Meter(this_)->updateMode((Meter*)(this_), m_)
 #define Meter_drawFn(this_)            As_Meter(this_)->draw
 #define Meter_doneFn(this_)            As_Meter(this_)->done
-#define Meter_setValues(this_, c_, i_) As_Meter(this_)->setValues((Meter*)(this_), c_, i_)
+#define Meter_updateValues(this_, buf_, sz_) \
+                                       As_Meter(this_)->updateValues((Meter*)(this_), buf_, sz_)
 #define Meter_defaultMode(this_)       As_Meter(this_)->defaultMode
 #define Meter_getItems(this_)          As_Meter(this_)->curItems
 #define Meter_setItems(this_, n_)      As_Meter(this_)->curItems = (n_)

--- a/SwapMeter.c
+++ b/SwapMeter.c
@@ -24,7 +24,7 @@ int SwapMeter_attributes[] = {
    SWAP
 };
 
-static void SwapMeter_setValues(Meter* this, char* buffer, int size) {
+static void SwapMeter_updateValues(Meter* this, char* buffer, int size) {
    int written;
    Platform_setSwapValues(this);
 
@@ -54,7 +54,7 @@ MeterClass SwapMeter_class = {
       .delete = Meter_delete,
       .display = SwapMeter_display,
    },
-   .setValues = SwapMeter_setValues, 
+   .updateValues = SwapMeter_updateValues,
    .defaultMode = BAR_METERMODE,
    .maxItems = 1,
    .total = 100.0,

--- a/TasksMeter.c
+++ b/TasksMeter.c
@@ -18,7 +18,7 @@ int TasksMeter_attributes[] = {
    CPU_KERNEL, PROCESS_THREAD, PROCESS, TASKS_RUNNING
 };
 
-static void TasksMeter_setValues(Meter* this, char* buffer, int len) {
+static void TasksMeter_updateValues(Meter* this, char* buffer, int len) {
    ProcessList* pl = this->pl;
    this->values[0] = pl->kernelThreads;
    this->values[1] = pl->userlandThreads;
@@ -72,7 +72,7 @@ MeterClass TasksMeter_class = {
       .delete = Meter_delete,
       .display = TasksMeter_display,
    },
-   .setValues = TasksMeter_setValues, 
+   .updateValues = TasksMeter_updateValues,
    .defaultMode = TEXT_METERMODE,
    .maxItems = 4,
    .total = 100.0,

--- a/UptimeMeter.c
+++ b/UptimeMeter.c
@@ -17,7 +17,7 @@ int UptimeMeter_attributes[] = {
    UPTIME
 };
 
-static void UptimeMeter_setValues(Meter* this, char* buffer, int len) {
+static void UptimeMeter_updateValues(Meter* this, char* buffer, int len) {
    int totalseconds = Platform_getUptime();
    if (totalseconds == -1) {
       snprintf(buffer, len, "(unknown)");
@@ -49,7 +49,7 @@ MeterClass UptimeMeter_class = {
       .extends = Class(Meter),
       .delete = Meter_delete
    },
-   .setValues = UptimeMeter_setValues, 
+   .updateValues = UptimeMeter_updateValues,
    .defaultMode = TEXT_METERMODE,
    .maxItems = 1,
    .total = 100.0,


### PR DESCRIPTION
Rationale (copied from htop issue #471):
The function name "setValues" is misleading. For most OOP (object-
oriented programming) contexts, setXXX functions mean they will change
some member variables of an object into something specified in
function arguments. But in the *Meter_setValues() case, the new values
are not from the arguments, but from a hard-coded source. The caller
is not supposed to change the values[] to anything it likes, but
rather to "update" the values from the source. Hence, updateValues is
a better name for this family of functions.