### PR TITLE
Fix macro Header_forEachColumn

### DIFF
--- a/Header.c
+++ b/Header.c
@@ -37,7 +37,7 @@ typedef struct Header_ {
 #endif
 
 #ifndef Header_forEachColumn
-#define Header_forEachColumn(this_, i_) for (int i_=0; i_ < this->nrColumns; i_++)
+#define Header_forEachColumn(this_, i_) for (int (i_)=0; (i_) < (this_)->nrColumns; ++(i_))
 #endif
 
 Header* Header_new(struct ProcessList_* pl, Settings* settings, int nrColumns) {

--- a/Header.h
+++ b/Header.h
@@ -28,7 +28,7 @@ typedef struct Header_ {
 #endif
 
 #ifndef Header_forEachColumn
-#define Header_forEachColumn(this_, i_) for (int i_=0; i_ < this->nrColumns; i_++)
+#define Header_forEachColumn(this_, i_) for (int (i_)=0; (i_) < (this_)->nrColumns; ++(i_))
 #endif
 
 Header* Header_new(struct ProcessList_* pl, Settings* settings, int nrColumns);


### PR DESCRIPTION
The (this_) token was not expanded properly, but the bug was not caught
because all uses of this macro specifies (this_)=this .

Also parenthesize macro tokens to prevent further problems.