### PR TITLE
FreeBSD: fix multithreaded CPU% in process list

### DIFF
--- a/freebsd/FreeBSDProcessList.c
+++ b/freebsd/FreeBSDProcessList.c
@@ -424,7 +424,7 @@ void ProcessList_goThroughEntries(ProcessList* this) {
 
    int cpus = this->cpuCount;
    int count = 0;
-   struct kinfo_proc* kprocs = kvm_getprocs(fpl->kd, KERN_PROC_ALL, 0, &count);
+   struct kinfo_proc* kprocs = kvm_getprocs(fpl->kd, KERN_PROC_PROC, 0, &count);
 
    for (int i = 0; i < count; i++) {
       struct kinfo_proc* kproc = &kprocs[i];
@@ -493,10 +493,6 @@ void ProcessList_goThroughEntries(ProcessList* this) {
             if (cpus > 1)
                proc->percent_cpu = proc->percent_cpu / (double) cpus;
          }
-      }
-      if (isIdleProcess == false && proc->percent_cpu >= 99.8) {
-         // don't break formatting
-         proc->percent_cpu = 99.8;
       }
 
       proc->priority = kproc->ki_pri.pri_level - PZERO;


### PR DESCRIPTION
This fixes an issue on FreeBSD where CPU usage is listed incorrect for multithreaded processes. 

In FreeBSD, the thread ID space is not shared with the process ID space, unlike on Linux. As a result, when htop calls `kvm_getprocs` using `KERN_PROC_ALL`, all individual threads are reported but some threads share the same PID. When htop slurps in everything yielded by `kvm_getprocs`, it erroneously concludes that all threads in a process are duplicates because they share a PID. The result is that only a single thread and its CPU consumption are reported in the process list. (E.g., if LWP 1000 and 1001 in process 4000 are both CPU-bound, htop will report only 100% CPU for PID 4000 rather than 200%.) Note that this does not affect the usage percentages shown by CPU bars.

A quick fix is to use `kvm_getprocs` with `KERN_PROC_PROC` rather than `KERN_PROC_ALL`: this will report only one item per PID, resulting potentially in `ki_pctcpu` > 100. This matches htop's behavior in Linux, except in Linux you can additionally see the individual thread IDs listed.