### PR TITLE
Fixes upon xStrdup(NULL) problem

### DIFF
--- a/XAlloc.c
+++ b/XAlloc.c
@@ -44,9 +44,6 @@ void* xRealloc(void* ptr, size_t size) {
 }
 
 char* xStrdup(const char* str) {
-   if (!str) {
-      fail();
-   }
    char* data = strdup(str);
    if (!data) {
       fail();

--- a/XAlloc.c
+++ b/XAlloc.c
@@ -5,6 +5,7 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
+#include <assert.h>
 #include <err.h>
 #include <stdlib.h>
 #include <string.h>
@@ -43,7 +44,19 @@ void* xRealloc(void* ptr, size_t size) {
    return data;
 }
 
-char* xStrdup(const char* str) {
+#undef xStrdup
+#undef xStrdup_
+#ifdef NDEBUG
+# define xStrdup_ xStrdup
+#else
+# define xStrdup(str_) (assert(str_), xStrdup_(str_))
+#endif
+
+#if ((__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 3))
+char* xStrdup_(const char* str) __attribute__((nonnull));
+#endif // GNU C 3.3 or later
+
+char* xStrdup_(const char* str) {
    char* data = strdup(str);
    if (!data) {
       fail();

--- a/XAlloc.h
+++ b/XAlloc.h
@@ -15,6 +15,18 @@ void* xCalloc(size_t nmemb, size_t size);
 
 void* xRealloc(void* ptr, size_t size);
 
-char* xStrdup(const char* str);
+#undef xStrdup
+#undef xStrdup_
+#ifdef NDEBUG
+# define xStrdup_ xStrdup
+#else
+# define xStrdup(str_) (assert(str_), xStrdup_(str_))
+#endif
+
+#if ((__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 3))
+char* xStrdup_(const char* str) __attribute__((nonnull));
+#endif // GNU C 3.3 or later
+
+char* xStrdup_(const char* str);
 
 #endif


### PR DESCRIPTION
The "Stricter strdup." 4674b4a commit is wrong. Checking whether the pointer argument is NULL helps nothing but increased code size. It would crash anyway on NULL no matter it has checking code or not.
This pull request reverts the commit, but also adds proper code to check xStrdup(NULL) bugs.
Namely, assertions (in macros) and `__attribute__((nonnull))`.