### PR TITLE
Fix xStrdup debug build failure & allow Clang to use ((nonnull))

### DIFF
--- a/XAlloc.c
+++ b/XAlloc.c
@@ -5,12 +5,12 @@
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
 #endif
-#include <assert.h>
 #include <err.h>
 #include <stdlib.h>
 #include <string.h>
 
 /*{
+#include <assert.h>
 #include <stdlib.h>
 }*/
 
@@ -52,9 +52,13 @@ void* xRealloc(void* ptr, size_t size) {
 # define xStrdup(str_) (assert(str_), xStrdup_(str_))
 #endif
 
-#if ((__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 3))
+#ifndef __has_attribute // Clang's macro
+# define __has_attribute(x) 0
+#endif
+#if (__has_attribute(nonnull) || \
+    ((__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 3)))
 char* xStrdup_(const char* str) __attribute__((nonnull));
-#endif // GNU C 3.3 or later
+#endif // __has_attribute(nonnull) || GNU C 3.3 or later
 
 char* xStrdup_(const char* str) {
    char* data = strdup(str);

--- a/XAlloc.h
+++ b/XAlloc.h
@@ -7,6 +7,7 @@
 #define _GNU_SOURCE
 #endif
 
+#include <assert.h>
 #include <stdlib.h>
 
 void* xMalloc(size_t size);
@@ -23,9 +24,13 @@ void* xRealloc(void* ptr, size_t size);
 # define xStrdup(str_) (assert(str_), xStrdup_(str_))
 #endif
 
-#if ((__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 3))
+#ifndef __has_attribute // Clang's macro
+# define __has_attribute(x) 0
+#endif
+#if (__has_attribute(nonnull) || \
+    ((__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 3)))
 char* xStrdup_(const char* str) __attribute__((nonnull));
-#endif // GNU C 3.3 or later
+#endif // __has_attribute(nonnull) || GNU C 3.3 or later
 
 char* xStrdup_(const char* str);
 


### PR DESCRIPTION
I mean, sorry for breaking the debug build. (For #504)
And by the way, it seems that GCC 5 also supports `__has_attribute` macro, which could be a more reliable way then checking GCC version. Nonetheless, I use both checks.