### PR TITLE
Implement option to collapse all entries in tree view

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -224,6 +224,15 @@ static Htop_Reaction actionToggleTreeView(State* st) {
    return HTOP_REFRESH | HTOP_SAVE_SETTINGS | HTOP_KEEP_FOLLOWING | HTOP_REDRAW_BAR | HTOP_UPDATE_PANELHDR;
 }
 
+static Htop_Reaction actionExpandOrCollapseAllTrees(State* st) {
+   st->settings->allTreesCollapsed = !st->settings->allTreesCollapsed;
+   if (st->settings->allTreesCollapsed)
+      ProcessList_collapseAllTrees(st->pl);
+   else
+      ProcessList_expandTree(st->pl);
+   return HTOP_REFRESH | HTOP_SAVE_SETTINGS;
+}
+
 static Htop_Reaction actionIncFilter(State* st) {
    IncSet* inc = ((MainPanel*)st->panel)->inc;
    IncSet_activate(inc, INC_FILTER, st->panel);
@@ -531,6 +540,7 @@ void Action_setBindings(Htop_Action* keys) {
    keys['p'] = actionToggleProgramPath;
    keys['t'] = actionToggleTreeView;
    keys[KEY_F(5)] = actionToggleTreeView;
+   keys['E'] = actionExpandOrCollapseAllTrees;
    keys[KEY_F(4)] = actionIncFilter;
    keys['\\'] = actionIncFilter;
    keys[KEY_F(3)] = actionIncSearch;

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -84,6 +84,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
 
    Panel_setHeader(super, "Display options");
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Tree view"), &(settings->treeView)));
+   Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Trees collapsed by default"), &(settings->allTreesCollapsed)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Shadow other users' processes"), &(settings->shadowOtherUsers)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Hide kernel threads"), &(settings->hideKernelThreads)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Hide userland process threads"), &(settings->hideUserlandThreads)));

--- a/Process.c
+++ b/Process.c
@@ -506,7 +506,7 @@ ProcessClass Process_class = {
 void Process_init(Process* this, struct Settings_* settings) {
    this->settings = settings;
    this->tag = false;
-   this->showChildren = true;
+   this->showChildren = !this->settings->allTreesCollapsed;
    this->show = true;
    this->updated = false;
    this->basenameOffset = -1;

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -265,6 +265,14 @@ void ProcessList_expandTree(ProcessList* this) {
    }
 }
 
+void ProcessList_collapseAllTrees(ProcessList* this) {
+   int size = Vector_size(this->processes);
+   for (int i = 0; i < size; i++) {
+      Process* process = (Process*) Vector_get(this->processes, i);
+      process->showChildren = false;
+   }
+}
+
 void ProcessList_rebuildPanel(ProcessList* this) {
    const char* incFilter = this->incFilter;
 

--- a/ProcessList.h
+++ b/ProcessList.h
@@ -93,6 +93,8 @@ ProcessField ProcessList_keyAt(ProcessList* this, int at);
 
 void ProcessList_expandTree(ProcessList* this);
 
+void ProcessList_collapseAllTrees(ProcessList* this);
+
 void ProcessList_rebuildPanel(ProcessList* this);
 
 Process* ProcessList_getProcess(ProcessList* this, pid_t pid, bool* preExisting, Process_New constructor);

--- a/Settings.c
+++ b/Settings.c
@@ -46,6 +46,7 @@ typedef struct Settings_ {
    bool countCPUsFromZero;
    bool detailedCPUTime;
    bool treeView;
+   bool allTreesCollapsed;
    bool showProgramPath;
    bool hideThreads;
    bool shadowOtherUsers;
@@ -192,6 +193,8 @@ static bool Settings_read(Settings* this, const char* fileName) {
          this->direction = atoi(option[1]);
       } else if (String_eq(option[0], "tree_view")) {
          this->treeView = atoi(option[1]);
+      } else if (String_eq(option[0], "all_trees_collapsed")) {
+         this->allTreesCollapsed = atoi(option[1]);
       } else if (String_eq(option[0], "hide_threads")) {
          this->hideThreads = atoi(option[1]);
       } else if (String_eq(option[0], "hide_kernel_threads")) {
@@ -299,6 +302,7 @@ bool Settings_write(Settings* this) {
    fprintf(fd, "highlight_megabytes=%d\n", (int) this->highlightMegabytes);
    fprintf(fd, "highlight_threads=%d\n", (int) this->highlightThreads);
    fprintf(fd, "tree_view=%d\n", (int) this->treeView);
+   fprintf(fd, "all_trees_collapsed=%d\n", (int) this->allTreesCollapsed);
    fprintf(fd, "header_margin=%d\n", (int) this->headerMargin);
    fprintf(fd, "detailed_cpu_time=%d\n", (int) this->detailedCPUTime);
    fprintf(fd, "cpu_count_from_zero=%d\n", (int) this->countCPUsFromZero);
@@ -326,6 +330,7 @@ Settings* Settings_new(int cpuCount) {
    this->hideKernelThreads = false;
    this->hideUserlandThreads = false;
    this->treeView = false;
+   this->allTreesCollapsed = false;
    this->highlightBaseName = false;
    this->highlightMegabytes = false;
    this->detailedCPUTime = false;

--- a/Settings.h
+++ b/Settings.h
@@ -37,6 +37,7 @@ typedef struct Settings_ {
    bool countCPUsFromZero;
    bool detailedCPUTime;
    bool treeView;
+   bool allTreesCollapsed;
    bool showProgramPath;
    bool hideThreads;
    bool shadowOtherUsers;

--- a/TESTPLAN
+++ b/TESTPLAN
@@ -55,7 +55,9 @@ Main screen:
 
       <l> - enter LSOF screen.
 
-      <m>, <n>, <o>, <p> - do nothing.
+      <m>, <n>, <o> - do nothing.
+
+      <p> - hide/show program path.
 
       <F10>, <q> - quit program.
 
@@ -73,7 +75,9 @@ Main screen:
       
       <F2>, <C>, <S> - enter Setup screen.
 
-      <D>, <E> - do nothing.
+      <D> - do nothing.
+
+      <E> - Expand or collapse all trees.
       
       <F> - follow process.
 


### PR DESCRIPTION
Added the ability to toggle (expand / collapse) all the trees in the tree view (by pressing the key 'E').

The preference is also made persistent using the settings, and can also be modified from Display Options menu.

I think this solves the issue #24 