### PR TITLE
Document Alt+{h,j,k,l} and Ctrl+{A,E} into man page

### DIFF
--- a/htop.1.in
+++ b/htop.1.in
@@ -48,8 +48,34 @@ Output version information and exit
 The following commands are supported while in htop:
 .LP 
 .TP 5
-.B Arrows, PgUP, PgDn, Home, End
-Scroll the process list.
+.B Up, Alt+k
+Select (hightlight) the previous process in the process list. Scroll the list
+if necessary.
+.TP
+.B Down, Alt-j
+Select (hightlight) the next process in the process list. Scroll the list if
+necessary.
+.TP
+.B Left, Alt-h
+Scroll the process list left.
+.TP
+.B Right, Alt-l
+Scroll the process list right.
+.TP
+.B PgUp, PgDn
+Scroll the process list up or down one window.
+.TP
+.B Home
+Scroll to the top of the process list and select the first process.
+.TP
+.B End
+Scroll to the bottom of the process list and select the last process.
+.TP
+.B Ctrl+A, ^
+Scroll left to the beginning of the process entry (i.e. beginning of line).
+.TP
+.B Ctrl+E, $
+Scroll right to the end of the process entry (i.e. end of line).
 .TP
 .B Space
 Tag or untag a process. Commands that can operate on multiple processes,


### PR DESCRIPTION
Rewrite the scrolling part in the man page so that each key become clearer on
what it does. Also officially document the Alt+{h,j,k,l} key alternatives and
Ctrl+A, Ctrl+E, '^', '$' keys (see issue #508).