### PR TITLE
Man page fix: Write '+' for key combinations (Ctrl+ or Alt+)

### DIFF
--- a/htop.1.in
+++ b/htop.1.in
@@ -52,14 +52,14 @@ The following commands are supported while in htop:
 Select (hightlight) the previous process in the process list. Scroll the list
 if necessary.
 .TP
-.B Down, Alt-j
+.B Down, Alt+j
 Select (hightlight) the next process in the process list. Scroll the list if
 necessary.
 .TP
-.B Left, Alt-h
+.B Left, Alt+h
 Scroll the process list left.
 .TP
-.B Right, Alt-l
+.B Right, Alt+l
 Scroll the process list right.
 .TP
 .B PgUp, PgDn
@@ -180,7 +180,7 @@ userspace processes in the process list. (This is a toggle key.)
 .B p
 Show full paths to running programs, where applicable. (This is a toggle key.)
 .TP
-.B Ctrl-L
+.B Ctrl+L
 Refresh: redraw screen and recalculate values.
 .TP
 .B Numbers


### PR DESCRIPTION
Be consistent. Most other GUI applications use '+' for key combinations joiner, only a few use '-'.