### PR TITLE
RFC: silence compiler warnings

### DIFF
--- a/EnvScreen.c
+++ b/EnvScreen.c
@@ -49,9 +49,9 @@ void EnvScreen_scan(InfoScreen* this) {
    Panel_prune(panel);
 
    uid_t euid = geteuid();
-   (void) seteuid(getuid());
+   if (seteuid(getuid())) {/* ignore return value */};
    char *env = Platform_getProcessEnv(this->process->pid);
-   (void) seteuid(euid);
+   if (seteuid(euid)) {/* ignore return value */};
    if (env) {
       for (char *p = env; *p; p = strrchr(p, 0)+1)
          InfoScreen_addLine(this, p);


### PR DESCRIPTION
For more recent GCC versions casting to (void) is not sufficient to
silence the warning about ignoring return values.

In the past we assigned the return value to a variable and casted that
to (void). Not really an elegant method.

How about mis-using a condition with empty body? This is just a RFC,
if you are happy I will catch some more cases and update the patch.
