### PR TITLE
Optimize GraphMeterMode_dots (now GraphMeterMode_styles)

### DIFF
--- a/Meter.h
+++ b/Meter.h
@@ -127,12 +127,11 @@ ListItem* Meter_toListItem(Meter* this, bool moving);
 
 /* ---------- GraphMeterMode ---------- */
 
-#ifdef HAVE_LIBNCURSESW
-
-#define PIXPERROW_UTF8 4
-#endif
-
-#define PIXPERROW_ASCII 2
+typedef enum {
+   GRAPHSTYLE_ASCII = 0, // Fallback default
+   GRAPHSTYLE_UTF8 = 1,  // UTF-8 default (braille)
+   LAST_GRAPHSTYLE       // Dummy & unused.
+} GraphStyleId;
 
 /* ---------- LEDMeterMode ---------- */
 


### PR DESCRIPTION
An attempt to optimize GraphMeterMode_dots from a array of strings into
a single string, removing the need of a bunch of pointers (to string
literals of each Braille code point). Now it uses padding instead.

The file-scope GraphMeterMode_pixPerRow and GraphMeterMode_dots
variables are now converted into local ones in GraphMeterMode_draw(),
for smaller code.

Technical note: The script MakeHeader.py does not (yet) allow me to
write a file-scope variable definition that span multiple lines without
enclosing definitions in braces {}, so GraphMeterMode_styles declared
as an array of strings is my way to workaround that script limit.
(The extensibility of GraphMeterMode_styles to coding more style in was
not part of original intention, but we have it anyway.)

```
$ gcc --version | head -n 1
gcc (Ubuntu 4.8.4-2ubuntu1~14.04.3) 4.8.4
$ uname -m
x86_64
$ size htop.old htop.new
   text   data   bss     dec    hex filename
 137929  15112  3776  156817  26491 htop.old
 137993  14792  3776  156561  26391 htop.new
```

Signed-off-by: Kang-Che Sung
