### PR TITLE
(Fix #532) Fix scrolling behavior change

### DIFF
--- a/Panel.c
+++ b/Panel.c
@@ -407,12 +407,13 @@ bool Panel_onKey(Panel* this, int key) {
       break;
    case KEY_PPAGE:
       this->selected -= (this->h - 1);
-      this->scrollV -= (this->h - 1);
+      this->scrollV = MAX(0, this->scrollV - this->h + 1);
       this->needsRedraw = true;
       break;
    case KEY_NPAGE:
       this->selected += (this->h - 1);
-      this->scrollV = MIN(MAX(0, Vector_size(this->items) - this->h), this->selected - this->h);
+      this->scrollV = MAX(0, MIN(Vector_size(this->items) - this->h,
+                                 this->scrollV + this->h - 1));
       this->needsRedraw = true;
       break;
    case KEY_WHEELUP:


### PR DESCRIPTION
Commit "Make PgDown behavior more usual." 759caf0f8fa593430adea676fc64612b5197dca8
silently changes the PageDown scrolling behavior that, instead of
scrolling one window down until the end of the window touches the end
of the list, the window simply repositions itself in a way that the
selected item always become the last item in the new window.

The commit reverts the behavior, and also fixes sanity conditionals
so that the scrollV variable will _never_ become negative or out-of-
bound.

Fixes issue #532. Also keep the problem #480 addressed.