### PR TITLE
Reject (alpha|sparc|mips|parisc)-linux* build targets.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,15 @@ darwin*)
    ;;
 esac
 
+dnl Signal tables for these architectures differ from other common ones
+dnl (x86, arm, and others) in Linux. Reject for now.
+dnl Hopefully htop can support them in the future.
+case "$target" in
+alpha*-linux* | sparc*-linux* | mips*-linux* | parisc*-linux*)
+   AC_MSG_ERROR([Target is not supported: $target])
+   ;;
+esac
+
 # Checks for libraries.
 # ----------------------------------------------------------------------
 AC_CHECK_LIB([m], [ceil], [], [missing_libraries="$missing_libraries libm"])


### PR DESCRIPTION
Signal tables for these architectures differ from other common ones
(x86, arm and others) in Linux.
Although it will be better to implement signal tables for these, we
reject these platforms for now until someone can work on implementing
that.

Note that configure options like
'--host=alpha-linux-gnu --target=i686-linux-gnu'
should continue to work, so that people who are ambitious can still
build it anyway, circumventing our target check.