### PR TITLE
Optimize Strings_startWith()

### DIFF
--- a/StringUtils.c
+++ b/StringUtils.c
@@ -17,9 +17,14 @@ in the source distribution for its full text.
 /*{
 #include <stdio.h>
 
-#define String_startsWith(s, match) (strstr((s), (match)) == (s))
+#define String_startsWith(s, match) (strncmp((s),(match),strlen(match)) == 0)
 #define String_contains_i(s1, s2) (strcasestr(s1, s2) != NULL)
 }*/
+
+/*
+ * String_startsWith gives better performance if strlen(match) can be computed
+ * at compile time (e.g. when they are immutable string literals). :)
+ */
 
 char* String_cat(const char* s1, const char* s2) {
    int l1 = strlen(s1);

--- a/StringUtils.h
+++ b/StringUtils.h
@@ -11,8 +11,13 @@ in the source distribution for its full text.
 
 #include <stdio.h>
 
-#define String_startsWith(s, match) (strstr((s), (match)) == (s))
+#define String_startsWith(s, match) (strncmp((s),(match),strlen(match)) == 0)
 #define String_contains_i(s1, s2) (strcasestr(s1, s2) != NULL)
+
+/*
+ * String_startsWith gives better performance if strlen(match) can be computed
+ * at compile time (e.g. when they are immutable string literals). :)
+ */
 
 char* String_cat(const char* s1, const char* s2);
 

--- a/linux/Battery.c
+++ b/linux/Battery.c
@@ -179,25 +179,6 @@ static inline ssize_t xread(int fd, void *buf, size_t count) {
   }
 }
 
-/**
- * Returns a pointer to the suffix of `str` if its beginning matches `prefix`.
- * Returns NULL if the prefix does not match.
- * Examples: 
- * match("hello world", "hello "); -> "world"
- * match("hello world", "goodbye "); -> NULL
- */
-static inline const char* match(const char* str, const char* prefix) {
-   for (;;) {
-      if (*prefix == '\0') {
-         return str;
-      }
-      if (*prefix != *str) {
-         return NULL;
-      }
-      prefix++; str++;
-   }
-}
-
 static void Battery_getSysData(double* level, ACPresence* isOnAC) {
       
    *level = 0;
@@ -240,6 +221,8 @@ static void Battery_getSysData(double* level, ACPresence* isOnAC) {
          bool full = false;
          bool now = false;
          while ((line = strsep(&buf, "\n")) != NULL) {
+   #define match(str,prefix) \
+           (String_startsWith(str,prefix) ? (str) + strlen(prefix) : NULL)
             const char* ps = match(line, "POWER_SUPPLY_");
             if (!ps) {
                continue;
@@ -266,6 +249,7 @@ static void Battery_getSysData(double* level, ACPresence* isOnAC) {
                continue;
             }
          }
+   #undef match
       } else if (entryName[0] == 'A') {
          if (*isOnAC != AC_ERROR) {
             continue;

--- a/linux/Battery.h
+++ b/linux/Battery.h
@@ -29,13 +29,6 @@ Linux battery readings written by Ian P. Hands (iphands@gmail.com, ihands@redhat
 // READ FROM /sys
 // ----------------------------------------
 
-/**
- * Returns a pointer to the suffix of `str` if its beginning matches `prefix`.
- * Returns NULL if the prefix does not match.
- * Examples: 
- * match("hello world", "hello "); -> "world"
- * match("hello world", "goodbye "); -> NULL
- */
 void Battery_getData(double* level, ACPresence* isOnAC);
 
 #endif


### PR DESCRIPTION
Use strncmp() combined with a strlen() will give better performance
than a strstr in worst case. Especially when the match prefix is a
constant and not a variable.

While we are at it, replace the match() function in linux/Battery.c,
which uses a naive algorithm, with a macro that does better job by
utilizing Strings_startWith().

    $ gcc --version | head -n 1
    gcc (Ubuntu 4.8.4-2ubuntu1~14.04.3) 4.8.4
    $ uname -m
    x86_64
    $ size htop.old htop.new
       text   data    bss    dec    hex filename
     137929  15112   3776 156817  26491 htop.old
     137784  15104   3776 156664  263f8 htop.new