### PR TITLE
Mark signal tables 'const'

### DIFF
--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -33,7 +33,7 @@ in the source distribution for its full text.
 
 ProcessField Platform_defaultFields[] = { PID, USER, PRIORITY, NICE, M_SIZE, M_RESIDENT, STATE, PERCENT_CPU, PERCENT_MEM, TIME, COMM, 0 };
 
-SignalItem Platform_signals[] = {
+const SignalItem Platform_signals[] = {
    { .name = " 0 Cancel",    .number =  0 },
    { .name = " 1 SIGHUP",    .number =  1 },
    { .name = " 2 SIGINT",    .number =  2 },
@@ -69,7 +69,7 @@ SignalItem Platform_signals[] = {
    { .name = "31 SIGUSR2",   .number = 31 },
 };
 
-unsigned int Platform_numberOfSignals = sizeof(Platform_signals)/sizeof(SignalItem);
+const unsigned int Platform_numberOfSignals = sizeof(Platform_signals)/sizeof(SignalItem);
 
 ProcessFieldData Process_fields[] = {
    [0] = { .name = "", .title = NULL, .description = NULL, .flags = 0, },

--- a/darwin/Platform.h
+++ b/darwin/Platform.h
@@ -22,9 +22,9 @@ in the source distribution for its full text.
 
 extern ProcessField Platform_defaultFields[];
 
-extern SignalItem Platform_signals[];
+extern const SignalItem Platform_signals[];
 
-extern unsigned int Platform_numberOfSignals;
+extern const unsigned int Platform_numberOfSignals;
 
 extern ProcessFieldData Process_fields[];
 

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -43,7 +43,7 @@ ProcessField Platform_defaultFields[] = { PID, USER, PRIORITY, NICE, M_SIZE, M_R
 
 int Platform_numberOfFields = LAST_PROCESSFIELD;
 
-SignalItem Platform_signals[] = {
+const SignalItem Platform_signals[] = {
    { .name = " 0 Cancel",    .number =  0 },
    { .name = " 1 SIGHUP",    .number =  1 },
    { .name = " 2 SIGINT",    .number =  2 },
@@ -80,7 +80,7 @@ SignalItem Platform_signals[] = {
    { .name = "33 SIGLIBRT",  .number = 33 },
 };
 
-unsigned int Platform_numberOfSignals = sizeof(Platform_signals)/sizeof(SignalItem);
+const unsigned int Platform_numberOfSignals = sizeof(Platform_signals)/sizeof(SignalItem);
 
 void Platform_setBindings(Htop_Action* keys) {
    (void) keys;

--- a/freebsd/Platform.h
+++ b/freebsd/Platform.h
@@ -24,9 +24,9 @@ extern ProcessField Platform_defaultFields[];
 
 extern int Platform_numberOfFields;
 
-extern SignalItem Platform_signals[];
+extern const SignalItem Platform_signals[];
 
-extern unsigned int Platform_numberOfSignals;
+extern const unsigned int Platform_numberOfSignals;
 
 void Platform_setBindings(Htop_Action* keys);
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -47,7 +47,7 @@ ProcessField Platform_defaultFields[] = { PID, USER, PRIORITY, NICE, M_SIZE, M_R
 
 int Platform_numberOfFields = LAST_PROCESSFIELD;
 
-SignalItem Platform_signals[] = {
+const SignalItem Platform_signals[] = {
    { .name = " 0 Cancel",    .number = 0 },
    { .name = " 1 SIGHUP",    .number = 1 },
    { .name = " 2 SIGINT",    .number = 2 },
@@ -84,7 +84,7 @@ SignalItem Platform_signals[] = {
    { .name = "31 SIGSYS",    .number = 31 },
 };
 
-unsigned int Platform_numberOfSignals = sizeof(Platform_signals)/sizeof(SignalItem);
+const unsigned int Platform_numberOfSignals = sizeof(Platform_signals)/sizeof(SignalItem);
 
 static Htop_Reaction Platform_actionSetIOPriority(State* st) {
    Panel* panel = st->panel;

--- a/linux/Platform.h
+++ b/linux/Platform.h
@@ -23,9 +23,9 @@ extern ProcessField Platform_defaultFields[];
 
 extern int Platform_numberOfFields;
 
-extern SignalItem Platform_signals[];
+extern const SignalItem Platform_signals[];
 
-extern unsigned int Platform_numberOfSignals;
+extern const unsigned int Platform_numberOfSignals;
 
 void Platform_setBindings(Htop_Action* keys);
 

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -99,7 +99,7 @@ int Platform_numberOfFields = LAST_PROCESSFIELD;
 /*
  * See /usr/include/sys/signal.h
  */
-SignalItem Platform_signals[] = {
+const SignalItem Platform_signals[] = {
    { .name = " 0 Cancel",    .number =  0 },
    { .name = " 1 SIGHUP",    .number =  1 },
    { .name = " 2 SIGINT",    .number =  2 },
@@ -136,7 +136,7 @@ SignalItem Platform_signals[] = {
    { .name = "32 SIGTHR",    .number = 32 },
 };
 
-unsigned int Platform_numberOfSignals = sizeof(Platform_signals)/sizeof(SignalItem);
+const unsigned int Platform_numberOfSignals = sizeof(Platform_signals)/sizeof(SignalItem);
 
 void Platform_setBindings(Htop_Action* keys) {
    (void) keys;

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -39,9 +39,9 @@ extern int Platform_numberOfFields;
 /*
  * See /usr/include/sys/signal.h
  */
-extern SignalItem Platform_signals[];
+extern const SignalItem Platform_signals[];
 
-extern unsigned int Platform_numberOfSignals;
+extern const unsigned int Platform_numberOfSignals;
 
 void Platform_setBindings(Htop_Action* keys);
 

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -23,11 +23,11 @@ in the source distribution for its full text.
 #include "UnsupportedProcess.h"
 }*/
 
-SignalItem Platform_signals[] = {
+const SignalItem Platform_signals[] = {
    { .name = " 0 Cancel",    .number =  0 },
 };
 
-unsigned int Platform_numberOfSignals = sizeof(Platform_signals)/sizeof(SignalItem);
+const unsigned int Platform_numberOfSignals = sizeof(Platform_signals)/sizeof(SignalItem);
 
 ProcessField Platform_defaultFields[] = { PID, USER, PRIORITY, NICE, M_SIZE, M_RESIDENT, STATE, PERCENT_CPU, PERCENT_MEM, TIME, COMM, 0 };
 

--- a/unsupported/Platform.h
+++ b/unsupported/Platform.h
@@ -15,9 +15,9 @@ in the source distribution for its full text.
 #include "SignalsPanel.h"
 #include "UnsupportedProcess.h"
 
-extern SignalItem Platform_signals[];
+extern const SignalItem Platform_signals[];
 
-extern unsigned int Platform_numberOfSignals;
+extern const unsigned int Platform_numberOfSignals;
 
 extern ProcessField Platform_defaultFields[];
 


### PR DESCRIPTION
Specifically, Platform_signals[] and Platform_numberOfSignals. Both are
not supposed to be mutable. Marking them 'const' puts them into rodata
sections in binary. And for Platform_numberOfSignals, this aids
optimization (aids only Link Time Optimization for now). :)
