### PR TITLE
Real-time signals support (kill command)

### DIFF
--- a/SignalsPanel.c
+++ b/SignalsPanel.c
@@ -31,13 +31,36 @@ Panel* SignalsPanel_new() {
    Panel* this = Panel_new(1, 1, 1, 1, true, Class(ListItem), FunctionBar_newEnterEsc("Send   ", "Cancel "));
    const int defaultSignal = SIGTERM;
    int defaultPosition = 15;
-   for(unsigned int i = 0; i < Platform_numberOfSignals; i++) {
+   unsigned int i;
+   for (i = 0; i < Platform_numberOfSignals; i++) {
       Panel_set(this, i, (Object*) ListItem_new(Platform_signals[i].name, Platform_signals[i].number));
       // signal 15 is not always the 15th signal in the table
       if (Platform_signals[i].number == defaultSignal) {
          defaultPosition = i;
       }
    }
+   #if (defined(SIGRTMIN) && defined(SIGRTMAX))
+   // Real-time signals.
+   // SIGRTMIN and SIGRTMAX expand to libc internal functions and we have to
+   // grab their numbers at runtime.
+   static char buf[15]; // 15 == sizeof("xx SIGRTMIN+nn")
+   int rtmax;
+   for (int sig = SIGRTMIN; sig <= (rtmax = SIGRTMAX); i++, sig++) {
+      // Every signal between SIGRTMIN and SIGRTMAX are denoted in "SIGRTMIN+n"
+      // notation. This matches glibc's strsignal(3) behavior.
+      // We deviate from behaviors of Bash, ksh and Solaris intentionally.
+      if (sig == rtmax) {
+         snprintf(buf, 15, "%2d SIGRTMAX", sig);
+      } else {
+         int n = sig - SIGRTMIN;
+         snprintf(buf, 15, "%2d SIGRTMIN%+d", sig, n);
+         if (n == 0) {
+            buf[11] = '\0';
+         }
+      }
+      Panel_set(this, i, (Object*) ListItem_new(buf, sig));
+   }
+   #endif
    Panel_setHeader(this, "Send signal:");
    Panel_setSelected(this, defaultPosition);
    return this;


### PR DESCRIPTION
SignalsPanel_new now fetches SIGRTMIN and SIGRTMAX and generates real-
time signals entries at runtime.