### PR TITLE
Meter_humanUnit() optimization. (Using __builtin_clz)

### DIFF
--- a/Meter.h
+++ b/Meter.h
@@ -17,6 +17,7 @@ in the source distribution for its full text.
 
 #include "ListItem.h"
 
+#include <limits.h>
 #include <sys/time.h>
 
 typedef struct Meter_ Meter;
@@ -106,6 +107,21 @@ typedef struct GraphData_ {
 #ifndef CLAMP
 #define CLAMP(x,low,high) (((x)>(high))?(high):(((x)<(low))?(low):(x)))
 #endif
+
+#ifndef __has_builtin
+# define __has_builtin(x) 0
+#endif
+#if (__has_builtin(__builtin_clz) || \
+    ((__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)))
+# define HAS_BUILTIN_CLZ 1
+/*
+ * ulog2(x): base-2 logarithm of (unsigned int) x, rounded down, but
+ *           ulog2(0U) will be undefined behavior.
+ * (You may use ulog2(x | 1) to define the (x == 0) behavior.)
+ */
+# define ulog2(x)   (CHAR_BIT*sizeof(unsigned int)-1-__builtin_clz(x))
+# define ullog2(x)  (CHAR_BIT*sizeof(unsigned long)-1-__builtin_clzl(x))
+#endif // __has_builtin(__builtin_clz) || GNU C 3.4 or later
 
 extern MeterClass Meter_class;
 


### PR DESCRIPTION
(This branch was actually my personal experiment of finding __builtin_clz applications. I'm going to introduce __builtin_clz anyway in my graph-color-new branch, as part of an optimization. However, I believed this builtin could be useful in other places, such as in this Meter_humanUnit(), while we often need integer base-2 logarithms. Another potential use would be in Process_humanNumber(), which I didn't tried rewriting yet.)

* Introduce __builtin_clz compiler built-in, which helps us implement a
  fast binary logarithm for unsigned ints (compare with libm's
  log2{,f,l} functions, which operate on floats). Add ulog2() and
  ullog2() macros for such logarithm operations.

```
/* It's a pity that C standard library doesn't have these yet. */
#if (__has_builtin(__builtin_clz) || \
    ((__GNUC__ > 3) || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)))
# define ulog2(x)   (CHAR_BIT*sizeof(unsigned int)-1-__builtin_clz(x))
# define ullog2(x)  (CHAR_BIT*sizeof(unsigned long)-1-__builtin_clzl(x))
#endif
```

* Meter_humanUnit() now utilizes __builtin_clz and ullog2() when
  supported by compiler, and fall-backs to using a loop when builtin is
  not available.
* Optimize the format string part of Meter_humanUnit(). Now concern
  about rounding halfways like 99.95 and 9.995 so that format
  "precisions" can be more precise.
* A micro-optimization is made to avoid "*" and the additional
  precision argument in the snprintf() format string. (This may be
  reverted by request.)