### PR TITLE
Snap package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ m4/
 missing
 stamp-h1
 
+# snaps
+*.snap
+parts/
+prime/
+snap/
+stage/

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: htop
+version: master
+summary: Interactive processes viewer
+description: |
+  Htop is an ncursed-based process viewer similar to top, but it
+  allows one to scroll the list vertically and horizontally to see
+  all processes and their full command lines.
+
+  Tasks related to processes (killing, renicing) can be done without
+  entering their PIDs.
+
+grade: stable
+confinement: strict
+
+apps:
+  htop:
+    command: bin/htop
+    plugs: [system-observe, process-control]
+
+parts:
+  htop:
+    plugin: autotools
+    source: .
+    build-packages: [libncursesw5-dev]

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -2,7 +2,7 @@ name: htop
 version: master
 summary: Interactive processes viewer
 description: |
-  Htop is an ncursed-based process viewer similar to top, but it
+  Htop is an ncurses-based process viewer similar to top, but it
   allows one to scroll the list vertically and horizontally to see
   all processes and their full command lines.
 


### PR DESCRIPTION
Hi! This adds support for building `htop` as a _snap_ package. Snaps are packages containing an application together with its dependencies, designed to be secure, sandboxed, containerised and easy to install and rollback (see http://snapcraft.io/ and https://www.ubuntu.com/desktop/snappy).

I'm the current de-facto maintainer of Ubuntu's `htop` snap, and it's actually one of the most popular ones with thousands of downloads so far. The project is currently hosted in Launchpad (https://launchpad.net/htop-snap), and it's [automatically built and published to the Ubuntu Store](https://launchpad.net/~maxiberta/+snap/htop-snap).

The whole idea of snaps is making building, packaging and distribution easier for app developers, so I thought you might be interested in getting this upstreamed.

To build a snap based on local code, just run `snapcraft`:

```
$ snapcraft 
Preparing to pull htop 
Pulling htop 
Preparing to build htop 
Building htop 
env NOCONFIGURE=1 ./autogen.sh
..
..
./configure --prefix=
..
..
make -j4
..
..
make  install-am
..
..
Staging htop
Priming htop
Snapping 'htop'  /      
Snapped htop_master_amd64.snap
```

(See also the [slightly different manifest](https://git.launchpad.net/htop-snap/tree/snapcraft.yaml) used by Launchpad's build bot).
