### PR TITLE
Replace all uses of sprintf with snprintf

### DIFF
--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -48,7 +48,7 @@ static void CPUMeter_init(Meter* this) {
    int cpu = this->param;
    if (this->pl->cpuCount > 1) {
       char caption[10];
-      sprintf(caption, "%-3d", Settings_cpuId(this->pl->settings, cpu - 1));
+      snprintf(caption, sizeof(caption), "%-3d", Settings_cpuId(this->pl->settings, cpu - 1));
       Meter_setCaption(this, caption);
    }
    if (this->param == 0)
@@ -74,44 +74,44 @@ static void CPUMeter_display(Object* cast, RichString* out) {
       RichString_append(out, CRT_colors[METER_TEXT], "absent");
       return;
    }
-   sprintf(buffer, "%5.1f%% ", this->values[CPU_METER_NORMAL]);
+   snprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_NORMAL]);
    RichString_append(out, CRT_colors[METER_TEXT], ":");
    RichString_append(out, CRT_colors[CPU_NORMAL], buffer);
    if (this->pl->settings->detailedCPUTime) {
-      sprintf(buffer, "%5.1f%% ", this->values[CPU_METER_KERNEL]);
+      snprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_KERNEL]);
       RichString_append(out, CRT_colors[METER_TEXT], "sy:");
       RichString_append(out, CRT_colors[CPU_KERNEL], buffer);
-      sprintf(buffer, "%5.1f%% ", this->values[CPU_METER_NICE]);
+      snprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_NICE]);
       RichString_append(out, CRT_colors[METER_TEXT], "ni:");
       RichString_append(out, CRT_colors[CPU_NICE_TEXT], buffer);
-      sprintf(buffer, "%5.1f%% ", this->values[CPU_METER_IRQ]);
+      snprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_IRQ]);
       RichString_append(out, CRT_colors[METER_TEXT], "hi:");
       RichString_append(out, CRT_colors[CPU_IRQ], buffer);
-      sprintf(buffer, "%5.1f%% ", this->values[CPU_METER_SOFTIRQ]);
+      snprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_SOFTIRQ]);
       RichString_append(out, CRT_colors[METER_TEXT], "si:");
       RichString_append(out, CRT_colors[CPU_SOFTIRQ], buffer);
       if (this->values[CPU_METER_STEAL]) {
-         sprintf(buffer, "%5.1f%% ", this->values[CPU_METER_STEAL]);
+         snprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_STEAL]);
          RichString_append(out, CRT_colors[METER_TEXT], "st:");
          RichString_append(out, CRT_colors[CPU_STEAL], buffer);
       }
       if (this->values[CPU_METER_GUEST]) {
-         sprintf(buffer, "%5.1f%% ", this->values[CPU_METER_GUEST]);
+         snprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_GUEST]);
          RichString_append(out, CRT_colors[METER_TEXT], "gu:");
          RichString_append(out, CRT_colors[CPU_GUEST], buffer);
       }
-      sprintf(buffer, "%5.1f%% ", this->values[CPU_METER_IOWAIT]);
+      snprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_IOWAIT]);
       RichString_append(out, CRT_colors[METER_TEXT], "wa:");
       RichString_append(out, CRT_colors[CPU_IOWAIT], buffer);
    } else {
-      sprintf(buffer, "%5.1f%% ", this->values[CPU_METER_KERNEL]);
+      snprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_KERNEL]);
       RichString_append(out, CRT_colors[METER_TEXT], "sys:");
       RichString_append(out, CRT_colors[CPU_KERNEL], buffer);
-      sprintf(buffer, "%5.1f%% ", this->values[CPU_METER_NICE]);
+      snprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_NICE]);
       RichString_append(out, CRT_colors[METER_TEXT], "low:");
       RichString_append(out, CRT_colors[CPU_NICE_TEXT], buffer);
       if (this->values[CPU_METER_IRQ]) {
-         sprintf(buffer, "%5.1f%% ", this->values[CPU_METER_IRQ]);
+         snprintf(buffer, sizeof(buffer), "%5.1f%% ", this->values[CPU_METER_IRQ]);
          RichString_append(out, CRT_colors[METER_TEXT], "vir:");
          RichString_append(out, CRT_colors[CPU_GUEST], buffer);
       }

--- a/LoadAverageMeter.c
+++ b/LoadAverageMeter.c
@@ -28,11 +28,11 @@ static void LoadAverageMeter_updateValues(Meter* this, char* buffer, int size) {
 static void LoadAverageMeter_display(Object* cast, RichString* out) {
    Meter* this = (Meter*)cast;
    char buffer[20];
-   sprintf(buffer, "%.2f ", this->values[0]);
+   snprintf(buffer, sizeof(buffer), "%.2f ", this->values[0]);
    RichString_write(out, CRT_colors[LOAD_AVERAGE_ONE], buffer);
-   sprintf(buffer, "%.2f ", this->values[1]);
+   snprintf(buffer, sizeof(buffer), "%.2f ", this->values[1]);
    RichString_append(out, CRT_colors[LOAD_AVERAGE_FIVE], buffer);
-   sprintf(buffer, "%.2f ", this->values[2]);
+   snprintf(buffer, sizeof(buffer), "%.2f ", this->values[2]);
    RichString_append(out, CRT_colors[LOAD_AVERAGE_FIFTEEN], buffer);
 }
 
@@ -48,7 +48,7 @@ static void LoadMeter_updateValues(Meter* this, char* buffer, int size) {
 static void LoadMeter_display(Object* cast, RichString* out) {
    Meter* this = (Meter*)cast;
    char buffer[20];
-   sprintf(buffer, "%.2f ", ((Meter*)this)->values[0]);
+   snprintf(buffer, sizeof(buffer), "%.2f ", ((Meter*)this)->values[0]);
    RichString_write(out, CRT_colors[LOAD], buffer);
 }
 

--- a/Process.c
+++ b/Process.c
@@ -198,7 +198,7 @@ void Process_setupColumnWidths() {
       snprintf(Process_titleBuffer[i], 20, "%*s ", digits, Process_pidColumns[i].label);
       Process_fields[Process_pidColumns[i].id].title = Process_titleBuffer[i];
    }
-   sprintf(Process_pidFormat, "%%%dd ", digits);
+   snprintf(Process_pidFormat, sizeof(Process_pidFormat), "%%%dd ", digits);
 }
 
 void Process_humanNumber(RichString* str, unsigned long number, bool coloring) {

--- a/TasksMeter.c
+++ b/TasksMeter.c
@@ -40,7 +40,7 @@ static void TasksMeter_display(Object* cast, RichString* out) {
    
    int processes = (int) this->values[2];
    
-   sprintf(buffer, "%d", processes);
+   snprintf(buffer, sizeof(buffer), "%d", processes);
    RichString_write(out, CRT_colors[METER_VALUE], buffer);
    int threadValueColor = CRT_colors[METER_VALUE];
    int threadCaptionColor = CRT_colors[METER_TEXT];
@@ -50,18 +50,18 @@ static void TasksMeter_display(Object* cast, RichString* out) {
    }
    if (!settings->hideUserlandThreads) {
       RichString_append(out, CRT_colors[METER_TEXT], ", ");
-      sprintf(buffer, "%d", (int)this->values[1]);
+      snprintf(buffer, sizeof(buffer), "%d", (int)this->values[1]);
       RichString_append(out, threadValueColor, buffer);
       RichString_append(out, threadCaptionColor, " thr");
    }
    if (!settings->hideKernelThreads) {
       RichString_append(out, CRT_colors[METER_TEXT], ", ");
-      sprintf(buffer, "%d", (int)this->values[0]);
+      snprintf(buffer, sizeof(buffer), "%d", (int)this->values[0]);
       RichString_append(out, threadValueColor, buffer);
       RichString_append(out, threadCaptionColor, " kthr");
    }
    RichString_append(out, CRT_colors[METER_TEXT], "; ");
-   sprintf(buffer, "%d", (int)this->values[3]);
+   snprintf(buffer, sizeof(buffer), "%d", (int)this->values[3]);
    RichString_append(out, CRT_colors[TASKS_RUNNING], buffer);
    RichString_append(out, CRT_colors[METER_TEXT], " running");
 }

--- a/TraceScreen.c
+++ b/TraceScreen.c
@@ -99,7 +99,7 @@ bool TraceScreen_forkTracer(TraceScreen* this) {
       dup2(this->fdpair[1], STDERR_FILENO);
       int ok = fcntl(this->fdpair[1], F_SETFL, O_NONBLOCK);
       if (ok != -1) {
-         sprintf(buffer, "%d", this->super.process->pid);
+         snprintf(buffer, sizeof(buffer), "%d", this->super.process->pid);
          execlp("strace", "strace", "-p", buffer, NULL);
       }
       const char* message = "Could not execute 'strace'. Please make sure it is available in your $PATH.";

--- a/UptimeMeter.c
+++ b/UptimeMeter.c
@@ -33,11 +33,11 @@ static void UptimeMeter_updateValues(Meter* this, char* buffer, int len) {
    }
    char daysbuf[15];
    if (days > 100) {
-      sprintf(daysbuf, "%d days(!), ", days);
+      snprintf(daysbuf, sizeof(daysbuf), "%d days(!), ", days);
    } else if (days > 1) {
-      sprintf(daysbuf, "%d days, ", days);
+      snprintf(daysbuf, sizeof(daysbuf), "%d days, ", days);
    } else if (days == 1) {
-      sprintf(daysbuf, "1 day, ");
+      snprintf(daysbuf, sizeof(daysbuf), "1 day, ");
    } else {
       daysbuf[0] = '\0';
    }


### PR DESCRIPTION
In all the cases where sprintf was being used within htop, snprintf
could have been used. This patch replaces all uses of sprintf with
snprintf which makes sure that if a buffer is too small to hold the
resulting string, the string is simply cut short instead of causing
a buffer overflow which leads to undefined behaviour.

`sizeof(variable)` was used in these cases, as opposed to `sizeof
variable` which is my personal preference because `sizeof(variable)`
was already used in one way or another in other parts of the code.