### PR TITLE
CPU clock rate can be displayed in meter instead of CPU load percentage

### DIFF
--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -63,7 +63,11 @@ static void CPUMeter_updateValues(Meter* this, char* buffer, int size) {
    }
    memset(this->values, 0, sizeof(double) * CPU_METER_ITEMCOUNT);
    double percent = Platform_setCPUValues(this, cpu);
-   snprintf(buffer, size, "%5.1f%%", percent);
+   if (this->pl->settings->showClockRate) {
+      snprintf(buffer, size, "%5.1lfMHz", this->clockRate);
+   } else {
+      snprintf(buffer, size, "%5.1f%%", percent);
+   }
 }
 
 static void CPUMeter_display(Object* cast, RichString* out) {

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -97,5 +97,6 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Count CPUs from 0 instead of 1"), &(settings->countCPUsFromZero)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Update process names on every refresh"), &(settings->updateProcessNames)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Add guest time in CPU meter percentage"), &(settings->accountGuestInCPUMeter)));
+   Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Show CPU clockrate instead of load percentage"), &(settings->showClockRate)));
    return this;
 }

--- a/Meter.c
+++ b/Meter.c
@@ -87,6 +87,7 @@ struct Meter_ {
    struct ProcessList_* pl;
    double* values;
    double total;
+   double clockRate;
 };
 
 typedef struct MeterMode_ {

--- a/Meter.h
+++ b/Meter.h
@@ -74,6 +74,7 @@ struct Meter_ {
    struct ProcessList_* pl;
    double* values;
    double total;
+   double clockRate;
 };
 
 typedef struct MeterMode_ {

--- a/Settings.c
+++ b/Settings.c
@@ -58,6 +58,7 @@ typedef struct Settings_ {
    bool updateProcessNames;
    bool accountGuestInCPUMeter;
    bool headerMargin;
+   bool showClockRate;
 
    bool changed;
 } Settings;
@@ -243,6 +244,8 @@ static bool Settings_read(Settings* this, const char* fileName) {
       } else if (String_eq(option[0], "right_meter_modes")) {
          Settings_readMeterModes(this, option[1], 1);
          readMeters = true;
+      } else if (String_eq(option[0], "show_clockrate")) {
+          this->showClockRate = atoi(option[1]);
       }
       String_freeArray(option);
    }
@@ -307,6 +310,7 @@ bool Settings_write(Settings* this) {
    fprintf(fd, "cpu_count_from_zero=%d\n", (int) this->countCPUsFromZero);
    fprintf(fd, "update_process_names=%d\n", (int) this->updateProcessNames);
    fprintf(fd, "account_guest_in_cpu_meter=%d\n", (int) this->accountGuestInCPUMeter);
+   fprintf(fd, "show_clockrate=%d\n", (int) this->showClockRate);
    fprintf(fd, "color_scheme=%d\n", (int) this->colorScheme);
    fprintf(fd, "delay=%d\n", (int) this->delay);
    fprintf(fd, "left_meters="); writeMeters(this, fd, 0);
@@ -337,6 +341,7 @@ Settings* Settings_new(int cpuCount) {
    this->cpuCount = cpuCount;
    this->showProgramPath = true;
    this->highlightThreads = true;
+   this->showClockRate = false;
    
    this->fields = xCalloc(Platform_numberOfFields+1, sizeof(ProcessField));
    // TODO: turn 'fields' into a Vector,

--- a/Settings.h
+++ b/Settings.h
@@ -49,6 +49,7 @@ typedef struct Settings_ {
    bool updateProcessNames;
    bool accountGuestInCPUMeter;
    bool headerMargin;
+   bool showClockRate;
 
    bool changed;
 } Settings;

--- a/linux/LinuxProcessList.h
+++ b/linux/LinuxProcessList.h
@@ -38,6 +38,7 @@ typedef struct CPUData_ {
    unsigned long long int softIrqPeriod;
    unsigned long long int stealPeriod;
    unsigned long long int guestPeriod;
+   double clockRate;
 } CPUData;
 
 typedef struct TtyDriver_ {
@@ -67,6 +68,10 @@ typedef struct LinuxProcessList_ {
 #define PROCMEMINFOFILE PROCDIR "/meminfo"
 #endif
 
+#ifndef PROCCPUINFOFILE
+#define PROCCPUINFOFILE PROCDIR "/cpuinfo"
+#endif
+
 #ifndef PROCTTYDRIVERSFILE
 #define PROCTTYDRIVERSFILE PROCDIR "/tty/drivers"
 #endif
@@ -79,6 +84,8 @@ typedef struct LinuxProcessList_ {
 #ifndef CLAMP
 #define CLAMP(x,low,high) (((x)>(high))?(high):(((x)<(low))?(low):(x)))
 #endif
+
+#define CLOCK_MASK "cpu MHz"
 
 ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, uid_t userId);
 
@@ -100,6 +107,7 @@ void ProcessList_delete(ProcessList* pl);
 #ifdef HAVE_VSERVER
 
 #endif
+
 
 void ProcessList_goThroughEntries(ProcessList* super);
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -166,6 +166,7 @@ int Platform_getMaxPid() {
 double Platform_setCPUValues(Meter* this, int cpu) {
    LinuxProcessList* pl = (LinuxProcessList*) this->pl;
    CPUData* cpuData = &(pl->cpus[cpu]);
+   this->clockRate = cpuData->clockRate;
    double total = (double) ( cpuData->totalPeriod == 0 ? 1 : cpuData->totalPeriod);
    double percent;
    double* v = this->values;


### PR DESCRIPTION
Modern CPU can change frequency in wide range. I think it may be useful just to see the freq in htop.

This feature is disabled by default and can be enabled in setup->display options. This commit affected only text in meter. Bar keeps show CPU load. Tested on Linux only.

![5v1br_croper_ru](https://cloud.githubusercontent.com/assets/14933849/22477638/48cebb52-e800-11e6-971e-34e1e89bea6b.png)
