### PR TITLE
Add missing include

### DIFF
--- a/TraceScreen.c
+++ b/TraceScreen.c
@@ -22,6 +22,7 @@ in the source distribution for its full text.
 #include <stdbool.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/time.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <signal.h>


### PR DESCRIPTION
sys/time.h for struct timeval.
(it is being side-loaded on some platforms)
