### PR TITLE
update keymap in help

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -395,7 +395,7 @@ static struct { const char* key; const char* info; } helpLeft[] = {
    { .key = " F6 + -: ", .info = "expand/collapse tree" },
    { .key = "  P M T: ", .info = "sort by CPU%, MEM% or TIME" },
    { .key = "      I: ", .info = "invert sort order" },
-   { .key = "   F6 >: ", .info = "select sort column" },
+   { .key = "< > , .: ", .info = "select sort column" },
    { .key = NULL, .info = NULL }
 };
 
@@ -414,7 +414,7 @@ static struct { const char* key; const char* info; } helpRight[] = {
    { .key = "      l: ", .info = "list open files with lsof" },
    { .key = "      s: ", .info = "trace syscalls with strace" },
    { .key = "         ", .info = "" },
-   { .key = "   F2 S: ", .info = "setup" },
+   { .key = " F2 C S: ", .info = "setup" },
    { .key = "   F1 h: ", .info = "show this help screen" },
    { .key = "  F10 q: ", .info = "quit" },
    { .key = NULL, .info = NULL }


### PR DESCRIPTION
I found `C` is used for setup, or configuration. meanwhile `F6` appears twice in the help page. So here's the fix.