### PR TITLE
fix SEGFAULT when removing laptop battery

### DIFF
--- a/linux/Battery.c
+++ b/linux/Battery.c
@@ -74,6 +74,8 @@ static unsigned long int parseBatInfo(const char *fileName, const unsigned short
 
       fclose(file);
 
+      if (!line) break;
+
       char *foundNumStr = String_getToken(line, wordNum);
       const unsigned long int foundNum = atoi(foundNumStr);
       free(foundNumStr);


### PR DESCRIPTION
If I remove battery from my laptop and try to run htop, it segfaults, because the content of `/proc/acpi/battery/BAT0/info` changes, which results in `line` variable still containing NULL when `parseBatInfo()` passes it to `String_getToken()`. `String_getToken()` then supplies `strlen()` with this unchecked `line`.