### PR TITLE
specify python version

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -158,7 +158,7 @@ static bool expandCollapse(Panel* panel) {
 Htop_Reaction Action_setSortKey(Settings* settings, ProcessField sortKey) {
    settings->sortKey = sortKey;
    settings->direction = 1;
-   settings->treeView = false;
+   settings->treeView = false; 
    return HTOP_REFRESH | HTOP_SAVE_SETTINGS | HTOP_UPDATE_PANELHDR | HTOP_KEEP_FOLLOWING;
 }
 

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -84,6 +84,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
 
    Panel_setHeader(super, "Display options");
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Tree view"), &(settings->treeView)));
+   Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Expand trees by default"), &(settings->expandTrees)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Shadow other users' processes"), &(settings->shadowOtherUsers)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Hide kernel threads"), &(settings->hideKernelThreads)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Hide userland process threads"), &(settings->hideUserlandThreads)));

--- a/Process.c
+++ b/Process.c
@@ -507,7 +507,7 @@ ProcessClass Process_class = {
 void Process_init(Process* this, struct Settings_* settings) {
    this->settings = settings;
    this->tag = false;
-   this->showChildren = true;
+   this->showChildren = settings->expandTrees;
    this->show = true;
    this->updated = false;
    this->basenameOffset = -1;

--- a/Settings.c
+++ b/Settings.c
@@ -58,6 +58,7 @@ typedef struct Settings_ {
    bool updateProcessNames;
    bool accountGuestInCPUMeter;
    bool headerMargin;
+   bool expandTrees;
 
    bool changed;
 } Settings;
@@ -243,6 +244,8 @@ static bool Settings_read(Settings* this, const char* fileName) {
       } else if (String_eq(option[0], "right_meter_modes")) {
          Settings_readMeterModes(this, option[1], 1);
          readMeters = true;
+      } else if (String_eq(option[0], "expand_tree")) {
+         this->expandTrees = atoi(option[1]);
       }
       String_freeArray(option);
    }
@@ -302,6 +305,7 @@ bool Settings_write(Settings* this) {
    fprintf(fd, "highlight_megabytes=%d\n", (int) this->highlightMegabytes);
    fprintf(fd, "highlight_threads=%d\n", (int) this->highlightThreads);
    fprintf(fd, "tree_view=%d\n", (int) this->treeView);
+   fprintf(fd, "expand_tree=%d\n", (int) this->expandTrees);
    fprintf(fd, "header_margin=%d\n", (int) this->headerMargin);
    fprintf(fd, "detailed_cpu_time=%d\n", (int) this->detailedCPUTime);
    fprintf(fd, "cpu_count_from_zero=%d\n", (int) this->countCPUsFromZero);
@@ -337,7 +341,8 @@ Settings* Settings_new(int cpuCount) {
    this->cpuCount = cpuCount;
    this->showProgramPath = true;
    this->highlightThreads = true;
-   
+   this->expandTrees = true;
+
    this->fields = xCalloc(Platform_numberOfFields+1, sizeof(ProcessField));
    // TODO: turn 'fields' into a Vector,
    // (and ProcessFields into proper objects).

--- a/Settings.h
+++ b/Settings.h
@@ -49,6 +49,7 @@ typedef struct Settings_ {
    bool updateProcessNames;
    bool accountGuestInCPUMeter;
    bool headerMargin;
+   bool expandTrees;
 
    bool changed;
 } Settings;

--- a/scripts/MakeHeader.py
+++ b/scripts/MakeHeader.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os, sys, string
 try:
    from cStringIO import StringIO


### PR DESCRIPTION
this will avoid compiling errors on distributions that use python3 as a global default (like, in my case, archlinux) 