### PR TITLE
Added the github issues page link in the 'report a bug at' error message

### DIFF
--- a/darwin/DarwinCRT.c
+++ b/darwin/DarwinCRT.c
@@ -15,7 +15,8 @@ void CRT_handleSIGSEGV(int sgn) {
    (void) sgn;
    CRT_done();
    #ifdef __APPLE__
-   fprintf(stderr, "\n\nhtop " VERSION " aborting. Please report bug at http://hisham.hm/htop\n");
+   fprintf(stderr, "\n\nhtop " VERSION " aborting. Please visit http://hisham.hm/htop\n");
+   fprintf(stderr, "\n\nor report a bug at https://github.com/hishamhm/htop/issues\n");
    #ifdef HAVE_EXECINFO_H
    size_t size = backtrace(backtraceArray, sizeof(backtraceArray) / sizeof(void *));
    fprintf(stderr, "\n Please include in your report the following backtrace: \n");

--- a/dragonflybsd/DragonFlyBSDCRT.c
+++ b/dragonflybsd/DragonFlyBSDCRT.c
@@ -17,7 +17,8 @@ in the source distribution for its full text.
 void CRT_handleSIGSEGV(int sgn) {
    (void) sgn;
    CRT_done();
-   fprintf(stderr, "\n\nhtop " VERSION " aborting. Please report bug at http://hisham.hm/htop\n");
+   fprintf(stderr, "\n\nhtop " VERSION " aborting. Please visit http://hisham.hm/htop\n");
+   fprintf(stderr, "\n\nor report a bug at https://github.com/hishamhm/htop/issues\n");
    #ifdef HAVE_EXECINFO_H
    size_t size = backtrace(backtraceArray, sizeof(backtraceArray) / sizeof(void *));
    fprintf(stderr, "\n Please include in your report the following backtrace: \n");

--- a/linux/LinuxCRT.c
+++ b/linux/LinuxCRT.c
@@ -17,7 +17,8 @@ void CRT_handleSIGSEGV(int sgn) {
    (void) sgn;
    CRT_done();
    #ifdef __linux
-   fprintf(stderr, "\n\nhtop " VERSION " aborting. Please report bug at http://hisham.hm/htop\n");
+   fprintf(stderr, "\n\nhtop " VERSION " aborting. Please visit http://hisham.hm/htop\n");
+   fprintf(stderr, "\n\nor report a bug at https://github.com/hishamhm/htop/issues\n");
    #ifdef HAVE_EXECINFO_H
    size_t size = backtrace(backtraceArray, sizeof(backtraceArray) / sizeof(void *));
    fprintf(stderr, "\n Please include in your report the following backtrace: \n");


### PR DESCRIPTION
Since the project is now on GitHub, I think it's better if we add its GitHub issues page address in the 'please report a bug' messages along with the official project page address.