### PR TITLE
Round values in graph drawing (instead of implicit truncate)

### DIFF
--- a/Meter.c
+++ b/Meter.c
@@ -406,8 +406,8 @@ static void GraphMeterMode_draw(Meter* this, int x, int y, int w) {
    }
    for (; i < nValues; i+=2, k++) {
       int pix = GraphMeterMode_pixPerRow * GRAPH_HEIGHT;
-      int v1 = CLAMP(data->values[i] * pix, 1, pix);
-      int v2 = CLAMP(data->values[i+1] * pix, 1, pix);
+      int v1 = CLAMP((int) lround(data->values[i] * pix), 1, pix);
+      int v2 = CLAMP((int) lround(data->values[i+1] * pix), 1, pix);
 
       int colorIdx = GRAPH_1;
       for (int line = 0; line < GRAPH_HEIGHT; line++) {


### PR DESCRIPTION
Hello.
I'm hoping to rework and adapt the "graph meter coloring & dynamic scaling" change (#487) so that it can merge on the current master. However, I wish to avoid repetitive "rebasing" and code tweaking in case of disagreements on some **minor behaviors**. Therefore I make this pull request.

This is more like a **question** than a pull to fix bugs.

The current behavior on the graph meter drawing is that values are **rounded toward zero** (a.k.a. truncate) to the number of dots (each bar) when drawing.
This proposal change to **round half away from zero**, using the round()/lround() function.

One of the result is that a CPU use of 99% may be presented as full bar on the graph, while in the current behavior, only strict 100.0% will be presented as full.

Will this be accepted, or should the current behavior be kept?