### PR TITLE
[WIP] Adds support for linux delay accounting

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -259,13 +259,13 @@ then
    AC_DEFINE(HAVE_SETUID_ENABLED, 1, [Define if setuid support should be enabled.])
 fi
 
-AC_ARG_ENABLE(netlink, [AS_HELP_STRING([--enable-netlink], [enable netlink support for Delay accounting])],, enable_netlink="no")
-if test "x$enable_netlink" = xyes
+AC_ARG_ENABLE(delayacct, [AS_HELP_STRING([--enable-delayacct], [enable linux delay accounting])],, enable_delayacct="no")
+if test "x$enable_delayacct" = xyes
 then
-   AC_CHECK_LIB([nl-genl-3], [genlmsg_put], [], [missing_libraries="$missing_libraries libnl-genl-3"])
-   AC_CHECK_LIB([nl-3], [nl_socket_alloc], [], [missing_libraries="$missing_libraries libnl-3"])
-   AC_CHECK_HEADERS([netlink/netlink.h],[:], [missing_headers="$missing_headers $ac_header"])
-   AC_CHECK_HEADERS([linux/taskstats.h],[:], [missing_headers="$missing_headers $ac_header"])
+   PKG_CHECK_MODULES(LIBNL3, libnl-3.0, [], [missing_libraries="$missing_libraries libnl-3"])
+   PKG_CHECK_MODULES(LIBNL3GENL, libnl-genl-3.0, [], [missing_libraries="$missing_libraries libnl-genl-3"])
+   CFLAGS+=" $LIBNL3_CFLAGS $LIBNL3GENL_CFLAGS"
+   LIBS+=" $LIBNL3_LIBS $LIBNL3GENL_LIBS"
    AC_DEFINE(HAVE_DELAYACCT, 1, [Define if delay accounting support should be enabled.])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -259,6 +259,17 @@ then
    AC_DEFINE(HAVE_SETUID_ENABLED, 1, [Define if setuid support should be enabled.])
 fi
 
+AC_ARG_ENABLE(netlink, [AS_HELP_STRING([--enable-netlink], [enable netlink support for Delay accounting])],, enable_netlink="no")
+if test "x$enable_netlink" = xyes
+then
+   AC_CHECK_LIB([nl-genl-3], [genlmsg_put], [], [missing_libraries="$missing_libraries libnl-genl-3"])
+   AC_CHECK_LIB([nl-3], [nl_socket_alloc], [], [missing_libraries="$missing_libraries libnl-3"])
+   AC_CHECK_HEADERS([netlink/netlink.h],[:], [missing_headers="$missing_headers $ac_header"])
+   AC_CHECK_HEADERS([linux/taskstats.h],[:], [missing_headers="$missing_headers $ac_header"])
+   AC_DEFINE(HAVE_DELAYACCT, 1, [Define if delay accounting support should be enabled.])
+fi
+
+
 # Bail out on errors.
 # ----------------------------------------------------------------------
 if test ! -z "$missing_libraries"; then

--- a/htop.1.in
+++ b/htop.1.in
@@ -370,6 +370,15 @@ The I/O scheduling class followed by the priority if the class supports it:
    \fBB\fR for Best-effort
    \fBid\fR for Idle
 .TP
+.B PERCENT_CPU_DELAY (CPUD%)
+The percentage of time spent waiting for a CPU (while runnable). Requires CAP_NET_ADMIN.
+.TP
+.B PERCENT_IO_DELAY (IOD%)
+The percentage of time spent waiting for the completion of synchronous block I/O. Requires CAP_NET_ADMIN.
+.TP
+.B PERCENT_SWAP_DELAY (SWAPD%)
+The percentage of time spent swapping in pages. Requires CAP_NET_ADMIN.
+.TP
 .B All other flags
 Currently unsupported (always displays '-').
 

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -456,11 +456,11 @@ long LinuxProcess_compare(const void* v1, const void* v2) {
       return (p2->oom - p1->oom);
    #ifdef HAVE_DELAYACCT
    case PERCENT_CPU_DELAY:
-      return (p2->cpu_delay_percent - p1->cpu_delay_percent);
+      return (p2->cpu_delay_percent > p1->cpu_delay_percent ? 1 : -1);
    case PERCENT_IO_DELAY:
-      return (p2->blkio_delay_percent - p1->blkio_delay_percent);
+      return (p2->blkio_delay_percent > p1->blkio_delay_percent ? 1 : -1);
    case PERCENT_SWAP_DELAY:
-      return (p2->swapin_delay_percent - p1->swapin_delay_percent);
+      return (p2->swapin_delay_percent > p1->swapin_delay_percent ? 1 : -1);
    #endif
    case IO_PRIORITY:
       return LinuxProcess_effectiveIOPriority(p1) - LinuxProcess_effectiveIOPriority(p2);

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -306,6 +306,15 @@ bool LinuxProcess_setIOPriority(LinuxProcess* this, IOPriority ioprio) {
    return (LinuxProcess_updateIOPriority(this) == ioprio);
 }
 
+#ifdef HAVE_DELAYACCT
+void LinuxProcess_printDelay(float delay_percent, char* buffer, int n) {
+  if (delay_percent == -1LL)
+    xSnprintf(buffer, n, " N/A  ");
+  else
+    xSnprintf(buffer, n, "%4.1f ", delay_percent);
+}
+#endif
+
 void LinuxProcess_writeField(Process* this, RichString* str, ProcessField field) {
    LinuxProcess* lp = (LinuxProcess*) this;
    bool coloring = this->settings->highlightMegabytes;
@@ -380,9 +389,9 @@ void LinuxProcess_writeField(Process* this, RichString* str, ProcessField field)
       break;
     }
    #ifdef HAVE_DELAYACCT
-   case PERCENT_CPU_DELAY: xSnprintf(buffer, n, "%4.1f ", lp->cpu_delay_percent); break;
-   case PERCENT_IO_DELAY: xSnprintf(buffer, n, "%4.1f ", lp->blkio_delay_percent); break;
-   case PERCENT_SWAP_DELAY: xSnprintf(buffer, n, "%4.1f ", lp->swapin_delay_percent); break;
+   case PERCENT_CPU_DELAY: LinuxProcess_printDelay(lp->cpu_delay_percent, buffer, n); break;
+   case PERCENT_IO_DELAY: LinuxProcess_printDelay(lp->blkio_delay_percent, buffer, n); break;
+   case PERCENT_SWAP_DELAY: LinuxProcess_printDelay(lp->swapin_delay_percent, buffer, n); break;
    #endif
    default:
       Process_writeField((Process*)this, str, field);

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -308,10 +308,11 @@ bool LinuxProcess_setIOPriority(LinuxProcess* this, IOPriority ioprio) {
 
 #ifdef HAVE_DELAYACCT
 void LinuxProcess_printDelay(float delay_percent, char* buffer, int n) {
-  if (delay_percent == -1LL)
+  if (delay_percent == -1LL) {
     xSnprintf(buffer, n, " N/A  ");
-  else
-    xSnprintf(buffer, n, "%4.1f ", delay_percent);
+  } else {
+    xSnprintf(buffer, n, "%4.1f  ", delay_percent);
+  }
 }
 #endif
 

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -129,6 +129,7 @@ typedef struct LinuxProcess_ {
    unsigned int oom;
    char* ttyDevice;
    #ifdef HAVE_DELAYACCT
+   unsigned long long int delay_read_time;
    unsigned long long cpu_delay_total;
    float cpu_delay_percent;
    #endif

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -387,7 +387,7 @@ void LinuxProcess_writeField(Process* this, RichString* str, ProcessField field)
          xSnprintf(buffer, n, "?? ");
       }
       break;
-    }
+   }
    #ifdef HAVE_DELAYACCT
    case PERCENT_CPU_DELAY: LinuxProcess_printDelay(lp->cpu_delay_percent, buffer, n); break;
    case PERCENT_IO_DELAY: LinuxProcess_printDelay(lp->blkio_delay_percent, buffer, n); break;
@@ -457,9 +457,9 @@ long LinuxProcess_compare(const void* v1, const void* v2) {
    #ifdef HAVE_DELAYACCT
    case PERCENT_CPU_DELAY:
       return (p2->cpu_delay_percent - p1->cpu_delay_percent);
-  case PERCENT_IO_DELAY:
+   case PERCENT_IO_DELAY:
       return (p2->blkio_delay_percent - p1->blkio_delay_percent);
-  case PERCENT_SWAP_DELAY:
+   case PERCENT_SWAP_DELAY:
       return (p2->swapin_delay_percent - p1->swapin_delay_percent);
    #endif
    case IO_PRIORITY:

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -73,7 +73,10 @@ typedef enum LinuxProcessFields {
    #endif
    OOM = 114,
    IO_PRIORITY = 115,
-   LAST_PROCESSFIELD = 116,
+   #ifdef HAVE_DELAYACCT
+   PERCENT_DELAY = 116,
+   #endif
+   LAST_PROCESSFIELD = 117,
 } LinuxProcessField;
 
 #include "IOPriority.h"
@@ -117,6 +120,10 @@ typedef struct LinuxProcess_ {
    #endif
    unsigned int oom;
    char* ttyDevice;
+   #ifdef HAVE_DELAYACCT
+   unsigned long long cpu_delay_total;
+   float cpu_delay_percent;
+   #endif
 } LinuxProcess;
 
 #ifndef Process_isKernelThread

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -121,6 +121,7 @@ typedef struct LinuxProcess_ {
    unsigned int oom;
    char* ttyDevice;
    #ifdef HAVE_DELAYACCT
+   unsigned long long int delay_read_time;
    unsigned long long cpu_delay_total;
    float cpu_delay_percent;
    #endif

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -74,9 +74,11 @@ typedef enum LinuxProcessFields {
    OOM = 114,
    IO_PRIORITY = 115,
    #ifdef HAVE_DELAYACCT
-   PERCENT_DELAY = 116,
+   PERCENT_CPU_DELAY = 116,
+   PERCENT_IO_DELAY = 117,
+   PERCENT_SWAP_DELAY = 118,
    #endif
-   LAST_PROCESSFIELD = 117,
+   LAST_PROCESSFIELD = 119,
 } LinuxProcessField;
 
 #include "IOPriority.h"
@@ -123,7 +125,11 @@ typedef struct LinuxProcess_ {
    #ifdef HAVE_DELAYACCT
    unsigned long long int delay_read_time;
    unsigned long long cpu_delay_total;
+   unsigned long long blkio_delay_total;
+   unsigned long long swapin_delay_total;
    float cpu_delay_percent;
+   float blkio_delay_percent;
+   float swapin_delay_percent;
    #endif
 } LinuxProcess;
 

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -166,6 +166,10 @@ IOPriority LinuxProcess_updateIOPriority(LinuxProcess* this);
 
 bool LinuxProcess_setIOPriority(LinuxProcess* this, IOPriority ioprio);
 
+#ifdef HAVE_DELAYACCT
+void LinuxProcess_printDelay(float delay_percent, char* buffer, int n);
+#endif
+
 void LinuxProcess_writeField(Process* this, RichString* str, ProcessField field);
 
 long LinuxProcess_compare(const void* v1, const void* v2);

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -603,23 +603,23 @@ static int handleNetlinkMsg(struct nl_msg *nlmsg, void *linuxProcess) {
   nlhdr = nlmsg_hdr(nlmsg);
 
   if (genlmsg_parse(nlhdr, 0, nlattrs, TASKSTATS_TYPE_MAX, NULL) < 0)
-      return NL_SKIP;
+    return NL_SKIP;
 
   if ((nlattr = nlattrs[TASKSTATS_TYPE_AGGR_PID]) || (nlattr = nlattrs[TASKSTATS_TYPE_NULL])) {
-      stats = nla_data(nla_next(nla_data(nlattr), &rem));
-      assert(lp->super.pid == stats->ac_pid);
-      timeDelta = (stats->ac_etime*1000 - lp->delay_read_time);
-      #define BOUNDS(x) isnan(x) ? 0.0 : (x > 100) ? 100.0 : x;
-      #define DELTAPERC(x,y) BOUNDS((float) (x - y) / timeDelta * 100);
-      lp->cpu_delay_percent = DELTAPERC(stats->cpu_delay_total, lp->cpu_delay_total);
-      lp->blkio_delay_percent = DELTAPERC(stats->blkio_delay_total, lp->blkio_delay_total);
-      lp->swapin_delay_percent = DELTAPERC(stats->swapin_delay_total, lp->swapin_delay_total);
-      #undef DELTAPERC
-      #undef BOUNDS
-      lp->swapin_delay_total = stats->swapin_delay_total;
-      lp->blkio_delay_total = stats->blkio_delay_total;
-      lp->cpu_delay_total = stats->cpu_delay_total;
-      lp->delay_read_time = stats->ac_etime*1000;
+    stats = nla_data(nla_next(nla_data(nlattr), &rem));
+    assert(lp->super.pid == stats->ac_pid);
+    timeDelta = (stats->ac_etime*1000 - lp->delay_read_time);
+    #define BOUNDS(x) isnan(x) ? 0.0 : (x > 100) ? 100.0 : x;
+    #define DELTAPERC(x,y) BOUNDS((float) (x - y) / timeDelta * 100);
+    lp->cpu_delay_percent = DELTAPERC(stats->cpu_delay_total, lp->cpu_delay_total);
+    lp->blkio_delay_percent = DELTAPERC(stats->blkio_delay_total, lp->blkio_delay_total);
+    lp->swapin_delay_percent = DELTAPERC(stats->swapin_delay_total, lp->swapin_delay_total);
+    #undef DELTAPERC
+    #undef BOUNDS
+    lp->swapin_delay_total = stats->swapin_delay_total;
+    lp->blkio_delay_total = stats->blkio_delay_total;
+    lp->cpu_delay_total = stats->cpu_delay_total;
+    lp->delay_read_time = stats->ac_etime*1000;
   }
   return NL_OK;
 }
@@ -630,11 +630,10 @@ static void LinuxProcessList_readDelayAcctData(LinuxProcessList* this, LinuxProc
   if (nl_socket_modify_cb(this->netlink_socket, NL_CB_VALID, NL_CB_CUSTOM, handleNetlinkMsg, process) < 0)
     return;
 
-  if (! (msg = nlmsg_alloc())) 
+  if (! (msg = nlmsg_alloc()))
     return;
 
-  if (! genlmsg_put(msg, NL_AUTO_PID, NL_AUTO_SEQ, this->netlink_family, 0, 
-      NLM_F_REQUEST, TASKSTATS_CMD_GET, TASKSTATS_VERSION))
+  if (! genlmsg_put(msg, NL_AUTO_PID, NL_AUTO_SEQ, this->netlink_family, 0, NLM_F_REQUEST, TASKSTATS_CMD_GET, TASKSTATS_VERSION))
     nlmsg_free(msg);
 
   if (nla_put_u32(msg, TASKSTATS_CMD_ATTR_PID, process->super.pid) < 0)
@@ -646,7 +645,7 @@ static void LinuxProcessList_readDelayAcctData(LinuxProcessList* this, LinuxProc
     process->cpu_delay_percent = -1LL;
     return;
   }
-    
+ 
   if (nl_recvmsgs_default(this->netlink_socket) < 0)
     return;
 }

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -82,6 +82,10 @@ typedef struct LinuxProcessList_ {
    CPUData* cpus;
    TtyDriver* ttyDrivers;
    
+   #ifdef HAVE_DELAYACCT
+   struct nl_sock *netlink_socket;
+   int netlink_family;
+   #endif
 } LinuxProcessList;
 
 #ifndef PROCDIR
@@ -202,12 +206,29 @@ static void LinuxProcessList_initTtyDrivers(LinuxProcessList* this) {
    this->ttyDrivers = ttyDrivers;
 }
 
+#ifdef HAVE_DELAYACCT
+
+static void LinuxProcessList_initNetlinkSocket(LinuxProcessList* this) {
+  this->netlink_socket = nl_socket_alloc();
+  if (this->netlink_socket == NULL)
+    return;
+  if (nl_connect(this->netlink_socket, NETLINK_GENERIC) < 0)
+    return;
+  this->netlink_family = genl_ctrl_resolve(this->netlink_socket, TASKSTATS_GENL_NAME);
+}
+
+#endif
+
 ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, uid_t userId) {
    LinuxProcessList* this = xCalloc(1, sizeof(LinuxProcessList));
    ProcessList* pl = &(this->super);
    ProcessList_init(pl, Class(LinuxProcess), usersTable, pidWhiteList, userId);
    
    LinuxProcessList_initTtyDrivers(this);
+
+   #ifdef HAVE_DELAYACCT
+   LinuxProcessList_initNetlinkSocket(this);
+   #endif
 
    // Update CPU count:
    FILE* file = fopen(PROCSTATFILE, "r");
@@ -244,6 +265,12 @@ void ProcessList_delete(ProcessList* pl) {
       }
       free(this->ttyDrivers);
    }
+   #ifdef HAVE_DELAYACCT
+   if (this->netlink_socket) {
+      nl_close(this->netlink_socket);
+      nl_socket_free(this->netlink_socket);
+   }
+   #endif
    free(this);
 }
 
@@ -564,60 +591,49 @@ static void LinuxProcessList_readOomData(LinuxProcess* process, const char* dirn
 
 #ifdef HAVE_DELAYACCT
 
-static int callback_message(struct nl_msg *nlmsg, void *arg) {
+static int handleNetlinkMsg(struct nl_msg *nlmsg, void *linuxProcess) {
   struct nlmsghdr *nlhdr;
   struct nlattr *nlattrs[TASKSTATS_TYPE_MAX + 1];
   struct nlattr *nlattr;
   struct taskstats *stats;
   int rem;
-  LinuxProcess* lp = (LinuxProcess*) arg;
+  LinuxProcess* lp = (LinuxProcess*) linuxProcess;
 
   nlhdr = nlmsg_hdr(nlmsg);
-  
+
   if (genlmsg_parse(nlhdr, 0, nlattrs, TASKSTATS_TYPE_MAX, NULL) < 0)
-      return -1;
+      return NL_SKIP;
 
   if ((nlattr = nlattrs[TASKSTATS_TYPE_AGGR_PID]) || (nlattr = nlattrs[TASKSTATS_TYPE_NULL])) {
       stats = nla_data(nla_next(nla_data(nlattr), &rem));
+      assert(lp->super.pid == stats->ac_pid);
       lp->cpu_delay_total = stats->cpu_delay_total / 10000000; // nano to hundreths
   }
-  return 0;
+  return NL_OK;
 }
 
-static void LinuxProcessList_readDelayAcctData(LinuxProcess* process) {
+static void LinuxProcessList_readDelayAcctData(LinuxProcessList* this, LinuxProcess* process) {
   struct nl_msg *msg;
-  struct nl_sock *sk;
-  int family;
-  sk = nl_socket_alloc();
-  if (sk == NULL) {
-    goto teardown;
-  }
-  if (nl_connect(sk, NETLINK_GENERIC) < 0)
-    goto teardown;
 
-  if ((family = genl_ctrl_resolve(sk, TASKSTATS_GENL_NAME)) == 0)
-    goto teardown;
-
-  if (nl_socket_modify_cb(sk, NL_CB_VALID, NL_CB_CUSTOM, callback_message, process) < 0)
-    goto teardown;
+  if (nl_socket_modify_cb(this->netlink_socket, NL_CB_VALID, NL_CB_CUSTOM, handleNetlinkMsg, process) < 0)
+    return;
 
   if (! (msg = nlmsg_alloc())) 
-    goto teardown;
+    return;
 
-  if (! genlmsg_put(msg, NL_AUTO_PID, NL_AUTO_SEQ, family, 0, 
+  if (! genlmsg_put(msg, NL_AUTO_PID, NL_AUTO_SEQ, this->netlink_family, 0, 
       NLM_F_REQUEST, TASKSTATS_CMD_GET, TASKSTATS_VERSION))
         goto teardown;
 
   if (nla_put_u32(msg, TASKSTATS_CMD_ATTR_PID, process->super.pid) < 0)
     goto teardown;
-  
-  if (nl_send_auto(sk, msg) < 0)
+
+  if (nl_send_auto(this->netlink_socket, msg) < 0)
     goto teardown;
 
-  nl_recvmsgs_default(sk);
+  nl_wait_for_ack(this->netlink_socket);
+  nl_recvmsgs_default(this->netlink_socket);
 teardown:
-  nl_close(sk);
-  nl_socket_free(sk);
   nlmsg_free(msg);
 }
 
@@ -823,7 +839,7 @@ static bool LinuxProcessList_recurseProcTree(LinuxProcessList* this, const char*
 
       #ifdef HAVE_DELAYACCT
         unsigned long long int lastdelay = lp->cpu_delay_total;
-        LinuxProcessList_readDelayAcctData(lp);
+        LinuxProcessList_readDelayAcctData(this, lp);
         lp->cpu_delay_percent = ((float) lp->cpu_delay_total - lastdelay) / (proc->time - lasttimes);
         if (isnan(lp->cpu_delay_percent)) lp->cpu_delay_percent = 0.0;
       #endif

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -635,14 +635,18 @@ static void LinuxProcessList_readDelayAcctData(LinuxProcessList* this, LinuxProc
 
   if (! genlmsg_put(msg, NL_AUTO_PID, NL_AUTO_SEQ, this->netlink_family, 0, 
       NLM_F_REQUEST, TASKSTATS_CMD_GET, TASKSTATS_VERSION))
-      nlmsg_free(msg);
+    nlmsg_free(msg);
 
   if (nla_put_u32(msg, TASKSTATS_CMD_ATTR_PID, process->super.pid) < 0)
     nlmsg_free(msg);
 
-  if (nl_send_sync(this->netlink_socket, msg) < 0)
+  if (nl_send_sync(this->netlink_socket, msg) < 0) {
+    process->swapin_delay_percent = -1LL;
+    process->blkio_delay_percent = -1LL;
+    process->cpu_delay_percent = -1LL;
     return;
-
+  }
+    
   if (nl_recvmsgs_default(this->netlink_socket) < 0)
     return;
 }

--- a/linux/LinuxProcessList.h
+++ b/linux/LinuxProcessList.h
@@ -9,6 +9,9 @@ Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
+#ifdef HAVE_DELAYACCT
+#endif
+
 
 #include "ProcessList.h"
 
@@ -98,6 +101,10 @@ void ProcessList_delete(ProcessList* pl);
 #endif
 
 #ifdef HAVE_VSERVER
+
+#endif
+
+#ifdef HAVE_DELAYACCT
 
 #endif
 

--- a/linux/LinuxProcessList.h
+++ b/linux/LinuxProcessList.h
@@ -56,6 +56,10 @@ typedef struct LinuxProcessList_ {
    CPUData* cpus;
    TtyDriver* ttyDrivers;
    
+   #ifdef HAVE_DELAYACCT
+   struct nl_sock *netlink_socket;
+   int netlink_family;
+   #endif
 } LinuxProcessList;
 
 #ifndef PROCDIR
@@ -81,6 +85,10 @@ typedef struct LinuxProcessList_ {
 
 #ifndef CLAMP
 #define CLAMP(x,low,high) (((x)>(high))?(high):(((x)<(low))?(low):(x)))
+#endif
+
+#ifdef HAVE_DELAYACCT
+
 #endif
 
 ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, uid_t userId);


### PR DESCRIPTION
This PR adds support for showing columns with [linux delay accounting](https://www.kernel.org/doc/Documentation/accounting/delay-accounting.txt). This is a WIP but I wanted to open up for reviews to check if I'm on the correct track (cc @hishamhm).

This information can be read from the netlink interface, and thus we set up a socket to read from that when initializing the LinuxProcessList (`LinuxProcessList_initNetlinkSocket`). After that, for each process we call `LinuxProcessList_readDelayAcctData`, which sends a message thru the socket after setting up a callback to get the answer from the Kernel. That callback sets the process total delay time attribute. We then set the delay percent as the percentage of time process cpu time since last scan.

TODOS:
- [x] To compile it with delay accounting support I had to do:
`./autogen.sh && ./configure --enable-netlink CFLAGS=-I/usr/include/libnl3 && make`
I'm not sure there is a portable way to add that CFLAGS to the configure.ac file. libnl uses pkg-config for that, we could use [PKG_CHECK_MODULES](https://autotools.io/pkgconfig/pkg_check_modules.html) but I read that is not recommended. Figure out if there is a portable way to provide the CLFAGS required for libnl/libnl-gen
- [x] figure out why `./configure.sh` prints: `configure: WARNING: netlink/netlink.h: accepted by the compiler, rejected by the preprocessor!` (probably related to the item above)
- [x] add columns for other kinds of delays (e.g io)
- [x] add documentation on the new columns and decide on naming


Related to #665. 