### PR TITLE
Hide internal symbols from the final binary

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,7 +12,7 @@ applications_DATA = htop.desktop
 pixmapdir = $(datadir)/pixmaps
 pixmap_DATA = htop.png
 
-htop_CFLAGS = -pedantic -Wall $(wextra_flag) -std=c99 -D_XOPEN_SOURCE_EXTENDED -DSYSCONFDIR=\"$(sysconfdir)\" -I"$(top_srcdir)/$(my_htop_platform)"
+htop_CFLAGS = -pedantic -Wall $(wextra_flag) $(fvisibility_flag) -std=c99 -D_XOPEN_SOURCE_EXTENDED -DSYSCONFDIR=\"$(sysconfdir)\" -I"$(top_srcdir)/$(my_htop_platform)"
 htop_LDFLAGS = 
 AM_CPPFLAGS = -DNDEBUG
 

--- a/configure.ac
+++ b/configure.ac
@@ -100,6 +100,19 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],[
 CFLAGS="$save_cflags"
 AC_SUBST(wextra_flag)
 
+save_cflags="${CFLAGS}"
+CFLAGS="$CFLAGS -fvisibility=hidden"
+AC_MSG_CHECKING([if compiler supports -fvisibility=hidden])
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([], [])],[
+   fvisibility_flag=-fvisibility=hidden
+   AC_MSG_RESULT([yes])
+],[
+   fvisibility_flag=
+   AC_MSG_RESULT([no])
+])
+CFLAGS="$save_cflags"
+AC_SUBST(fvisibility_flag)
+
 # Checks for features and flags.
 # ----------------------------------------------------------------------
 PROCDIR=/proc


### PR DESCRIPTION
Probe for -fvisibility=hidden and use it.
This way all the internal symbols are hidden, reducing the size of the
binary by ~10%.