### PR TITLE
Minor quoting fix in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -268,7 +268,7 @@ if test ! -z "$missing_headers"; then
   AC_MSG_ERROR([missing headers: $missing_headers])
 fi
 
-AC_DEFINE_UNQUOTED(COPYRIGHT, "(C) 2004-$year Hisham Muhammad", [Copyright message.])
+AC_DEFINE_UNQUOTED(COPYRIGHT, ["(C) 2004-$year Hisham Muhammad"], [Copyright message.])
 
 # We're done, let's go!
 # ----------------------------------------------------------------------


### PR DESCRIPTION
This lack of quotes breaks syntax highlighting of gedit.
No effect on configure script generation, though.