### PR TITLE
Add support for Linux TASK_IDLE

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -174,6 +174,8 @@ typedef struct ProcessClass_ {
 
 #define Process_isChildOf(process_, pid_) (process_->tgid == pid_ || (process_->tgid == process_->pid && process_->ppid == pid_))
 
+#define Process_sortState(state) ((state) == 'I' ? 0x100 : (state))
+
 }*/
 
 static int Process_getuid = -1;
@@ -598,7 +600,7 @@ long Process_compare(const void* v1, const void* v2) {
          return (p1->starttime_ctime - p2->starttime_ctime);
    }
    case STATE:
-      return (p1->state - p2->state);
+      return (Process_sortState(p1->state) - Process_sortState(p2->state));
    case ST_UID:
       return (p1->st_uid - p2->st_uid);
    case TIME:

--- a/Process.h
+++ b/Process.h
@@ -153,6 +153,8 @@ typedef struct ProcessClass_ {
 
 #define Process_isChildOf(process_, pid_) (process_->tgid == pid_ || (process_->tgid == process_->pid && process_->ppid == pid_))
 
+#define Process_sortState(state) ((state) == 'I' ? 0x100 : (state))
+
 
 #define ONE_K 1024L
 #define ONE_M (ONE_K * ONE_K)

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -155,7 +155,7 @@ ProcessFieldData Process_fields[] = {
    [0] = { .name = "", .title = NULL, .description = NULL, .flags = 0, },
    [PID] = { .name = "PID", .title = "    PID ", .description = "Process/thread ID", .flags = 0, },
    [COMM] = { .name = "Command", .title = "Command ", .description = "Command line", .flags = 0, },
-   [STATE] = { .name = "STATE", .title = "S ", .description = "Process state (S sleeping, R running, D disk, Z zombie, T traced, W paging)", .flags = 0, },
+   [STATE] = { .name = "STATE", .title = "S ", .description = "Process state (S sleeping, R running, D disk, Z zombie, T traced, W paging, I idle)", .flags = 0, },
    [PPID] = { .name = "PPID", .title = "   PPID ", .description = "Parent process ID", .flags = 0, },
    [PGRP] = { .name = "PGRP", .title = "   PGRP ", .description = "Process group ID", .flags = 0, },
    [SESSION] = { .name = "SESSION", .title = "    SID ", .description = "Process's session ID", .flags = 0, },


### PR DESCRIPTION
```
Linux commit 06eb61844d841d0032a9950ce7f8e783ee49c0d0 ("sched/debug:
Add explicit TASK_IDLE printing") exposes kthreads idling using
TASK_IDLE in procfs as "I (idle)".

Until now, when sorting the STATE ("S") column, htop used the raw
value of the state character for comparison, however that led to the
undesirable effect of TASK_IDLE ('I') tasks being sorted above tasks
that were running ('R').

Thus, explicitly recognize the idle process state, and sort it below
others.
```