### PR TITLE
Put an upper bound on the number of runningTasks reported

### DIFF
--- a/TasksMeter.c
+++ b/TasksMeter.c
@@ -23,7 +23,7 @@ static void TasksMeter_updateValues(Meter* this, char* buffer, int len) {
    this->values[0] = pl->kernelThreads;
    this->values[1] = pl->userlandThreads;
    this->values[2] = pl->totalTasks - pl->kernelThreads - pl->userlandThreads;
-   this->values[3] = pl->runningTasks;
+   this->values[3] = MIN(pl->runningTasks, pl->cpuCount);
    if (pl->totalTasks > this->total) {
       this->total = pl->totalTasks;
    }


### PR DESCRIPTION
htop scans /proc to determine how many running tasks exist. Since that operation is not possible to be conducted in an atomic fashion, task scheduling effects can lead to a count greater than the number of actual processors; this is more easily noticed on machines with several CPUs and under heavy workload.

This patch simply adds an upper bound on cpuCount to guarantee consistent reports of the number of running tasks at any given time.