### PR TITLE
keep scan thread for version before high sierra

### DIFF
--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -21,49 +21,30 @@ in the source distribution for its full text.
 #include <sys/sysctl.h>
 #include <stdbool.h>
 
-void GetKernelVersion(int * major, int * minor, int * internal) {
-   static int cMajor = 0;
-   static int cMinor = 0;
-   static int cInternal = 0;
-   if (!cMajor) {
+struct kern {
+    short int version[3];
+};
+
+void GetKernelVersion(struct kern *k) {
+   static short int version_[3] = {0};
+   if (!version_[0]) {
       // just in case it fails someday
-      cMajor = cMinor = cInternal = -1;
+      version_[0] = version_[1] = version_[2] = -1;
       char str[256] = {0};
       size_t size = sizeof(str);
       int ret = sysctlbyname("kern.osrelease", str, &size, NULL, 0);
-      if (ret == 0) {
-         sscanf(str, "%d.%d.%d", &cMajor, &cMinor, &cInternal);
-      }
+      if (ret == 0) sscanf(str, "%hd.%hd.%hd", &version_[0], &version_[1], &version_[2]);
     }
-    *major = cMajor;
-    *minor = cMinor;
-    *internal = cInternal;
+    memcpy(k->version, version_, sizeof(version_));
 }
 
-bool IsKernelVersionUpperOrEqual(int major, int minor, int internal) {
-   int maj, min, inter;
-
-   GetKernelVersion(&maj, &min, &inter);
-
-   if ( maj > major) return true;
-   if ( maj == major) {
-      if ( min > minor ) return true;
-      else if ( min == minor && inter >= internal ) return true;
-   }
-   return false;
-}
-
-bool IsKernelVersionLessOrEqual(int major, int minor, int internal) {
-   int maj, min, inter;
-
-   GetKernelVersion(&maj, &min, &inter);
-
-   if ( maj < major) return true;
-   if ( maj == major) {
-      if ( min < minor ) return true;
-      else if ( min == minor && inter <= internal ) return true;
-   }
-   return false;
+int CompareKernelVersion(short int major, short int minor, short int component) {
+    struct kern k;
+    GetKernelVersion(&k);
+    if ( k.version[0] !=  major) return major - k.version[0];
+    if ( k.version[1] !=  minor) return minor - k.version[1];
+    if ( k.version[2] !=  component) return component - k.version[2];
+    return 0;
 }
 
 /*{
@@ -219,7 +200,7 @@ void ProcessList_goThroughEntries(ProcessList* super) {
        DarwinProcess_setFromLibprocPidinfo(proc, dpl);
 
        // Disabled for High Sierra due to bug in macOS High Sierra
-       bool isScanThreadSupported  = ! ( IsKernelVersionUpperOrEqual(17, 0, 0) && IsKernelVersionLessOrEqual(17, 4, 0));
+       bool isScanThreadSupported  = ! ( CompareKernelVersion(17, 0, 0) >= 0 && CompareKernelVersion(17, 5, 0) < 0);
 
        if (isScanThreadSupported){
            DarwinProcess_scanThreads(proc);


### PR DESCRIPTION
@hishamhm As said this should do the trick to keep thread info for those who don't have High Sierra.

Unfortunately I don't know the exact version failling.