### PR TITLE
Add <sys/sysmacros.h> to two files.

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -19,6 +19,9 @@ in the source distribution for its full text.
 #include <sys/param.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifdef HAVE_SYS_SYSMACROS_H
+# include <sys/sysmacros.h>	/* for major, minor */
+#endif
 #include <unistd.h>
 #include <stdlib.h>
 #include <signal.h>

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -25,6 +25,7 @@ in the source distribution for its full text.
 #include <time.h>
 #include <assert.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <fcntl.h>
 
 #ifdef HAVE_DELAYACCT


### PR DESCRIPTION
Future glibc releases will no longer include sysmacros implicitly.