### PR TITLE
Fix build failure ('major' undefined) in glibc 2.28.

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -28,6 +28,12 @@ in the source distribution for its full text.
 #include <time.h>
 #include <assert.h>
 #include <math.h>
+#ifdef MAJOR_IN_MKDEV
+#include <sys/mkdev.h>
+#elif defined(MAJOR_IN_SYSMACROS) || \
+   (defined(HAVE_SYS_SYSMACROS_H) && HAVE_SYS_SYSMACROS_H)
+#include <sys/sysmacros.h>
+#endif
 
 #ifdef __ANDROID__
 #define SYS_ioprio_get __NR_ioprio_get

--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,16 @@ AC_CHECK_HEADERS([stdlib.h string.h strings.h sys/param.h sys/time.h unistd.h],[
 ])
 AC_CHECK_HEADERS([execinfo.h],[:],[:])
 
+AC_HEADER_MAJOR
+dnl glibc 2.25 deprecates 'major' and 'minor' in <sys/types.h> and requires to
+dnl include <sys/sysmacros.h>. However the logic in AC_HEADER_MAJOR has not yet
+dnl been updated in Autoconf 2.69, so use a workaround:
+m4_version_prereq([2.70], [],
+[if test $ac_cv_header_sys_mkdev_h = no; then
+   AC_CHECK_HEADER(sys/sysmacros.h, [AC_DEFINE(MAJOR_IN_SYSMACROS, 1,
+      [Define to 1 if `major', `minor', and `makedev' are declared in <sys/sysmacros.h>.])])
+fi])
+
 # Checks for typedefs, structures, and compiler characteristics.
 # ----------------------------------------------------------------------
 AC_HEADER_STDBOOL

--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -26,6 +26,12 @@ in the source distribution for its full text.
 #include <assert.h>
 #include <sys/types.h>
 #include <fcntl.h>
+#ifdef MAJOR_IN_MKDEV
+#include <sys/mkdev.h>
+#elif defined(MAJOR_IN_SYSMACROS) || \
+   (defined(HAVE_SYS_SYSMACROS_H) && HAVE_SYS_SYSMACROS_H)
+#include <sys/sysmacros.h>
+#endif
 
 #ifdef HAVE_DELAYACCT
 #include <netlink/attr.h>


### PR DESCRIPTION
glibc 2.28 no longer defines 'major' and 'minor' in <sys/types.h> and
requires us to include <sys/sysmacros.h>. (glibc 2.25 starts
deprecating the macros in <sys/types.h>.) Now do include the latter if
found on the system.

At the moment, let's also utilize AC_HEADER_MAJOR in configure script.
However as Autoconf 2.69 has not yet updated the AC_HEADER_MAJOR macro
to reflect the glibc change [1], we need a workaround code.

Fixes #663. Supersedes pull request #729.

Reference:
[1] https://git.savannah.gnu.org/gitweb/?p=autoconf.git;a=commit;h=e17a30e987d7ee695fb4294a82d987ec3dc9b974