### PR TITLE
Changed type in StringUtils.c to avoid integer overflows

### DIFF
--- a/StringUtils.c
+++ b/StringUtils.c
@@ -27,11 +27,11 @@ in the source distribution for its full text.
  */
 
 char* String_cat(const char* s1, const char* s2) {
-   int l1 = strlen(s1);
-   int l2 = strlen(s2);
+   size_t l1 = strlen(s1);
+   size_t l2 = strlen(s2);
    char* out = xMalloc(l1 + l2 + 1);
    strncpy(out, s1, l1);
-   strncpy(out+l1, s2, l2+1);
+   strncpy(out + l1, s2, l2 + 1);
    return out;
 }
 
@@ -39,7 +39,7 @@ char* String_trim(const char* in) {
    while (in[0] == ' ' || in[0] == '\t' || in[0] == '\n') {
       in++;
    }
-   int len = strlen(in);
+   size_t len = strlen(in);
    while (len > 0 && (in[len-1] == ' ' || in[len-1] == '\t' || in[len-1] == '\n')) {
       len--;
    }
@@ -80,7 +80,7 @@ char** String_split(const char* s, char sep, int* n) {
       s += size + 1;
    }
    if (s[0] != '\0') {
-      int size = strlen(s);
+      size_t size = strlen(s);
       char* token = xMalloc(size + 1);
       strncpy(token, s, size + 1);
       out[ctr] = token;


### PR DESCRIPTION
Some return values from functions that return size_t were assigned to variables from type int. There are cases where sizeof(size_t) > sizeof(int). There are malloc calls influenced by these variables.