### PR TITLE
Solaris: assorted fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -243,6 +243,7 @@ fi
 
 if test "$my_htop_platform" = "solaris"; then
    AC_CHECK_LIB([kstat], [kstat_open], [], [missing_libraries="$missing_libraries libkstat"])
+   AC_CHECK_LIB([malloc], [free], [], [missing_libraries="$missing_libraries libmalloc"])
 fi
 
 AC_ARG_ENABLE(linux_affinity, [AS_HELP_STRING([--enable-linux-affinity], [enable Linux sched_setaffinity and sched_getaffinity for affinity support, disables hwloc])], ,enable_linux_affinity="yes")

--- a/solaris/SolarisCRT.c
+++ b/solaris/SolarisCRT.c
@@ -1,6 +1,7 @@
 /*
 htop - SolarisCRT.c
 (C) 2014 Hisham H. Muhammad
+(C) 2018 Guy M. Broome
 Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
@@ -9,13 +10,23 @@ in the source distribution for its full text.
 #include "CRT.h"
 #include <stdio.h>
 #include <stdlib.h>
+#ifdef HAVE_EXECINFO_H
+#include <execinfo.h>
+#endif
 
 void CRT_handleSIGSEGV(int sgn) {
    (void) sgn;
    CRT_done();
-   fprintf(stderr, "\n\nhtop " VERSION " aborting.\n");
-   fprintf(stderr, "\nUnfortunately, you seem to be using an unsupported platform!");
-   fprintf(stderr, "\nPlease contact your platform package maintainer!\n\n");
+   fprintf(stderr, "\n\nhtop " VERSION " aborting. Please report bug at http://hisham.hm/htop\n");
+   #ifdef HAVE_EXECINFO_H
+   size_t size = backtrace(backtraceArray, sizeof(backtraceArray) / sizeof(void *));
+   fprintf(stderr, "\n Please include in your report the following backtrace: \n");
+   backtrace_symbols_fd(backtraceArray, size, 2);
+   fprintf(stderr, "\nAdditionally, in order to make the above backtrace useful,");
+   fprintf(stderr, "\nplease also run the following command to generate a disassembly of your binary:");
+   fprintf(stderr, "\n\n   objdump -d `which htop` > ~/htop.objdump");
+   fprintf(stderr, "\n\nand then attach the file ~/htop.objdump to your bug report.");
+   fprintf(stderr, "\n\nThank you for helping to improve htop!\n\n");
+   #endif
    abort();
 }
-

--- a/solaris/SolarisCRT.h
+++ b/solaris/SolarisCRT.h
@@ -5,11 +5,14 @@
 /*
 htop - SolarisCRT.h
 (C) 2014 Hisham H. Muhammad
+(C) 2018 Guy M. Broome
 Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */
 
-void CRT_handleSIGSEGV(int sgn);
+#ifdef HAVE_EXECINFO_H
+#endif
 
+void CRT_handleSIGSEGV(int sgn);
 
 #endif

--- a/solaris/SolarisProcess.c
+++ b/solaris/SolarisProcess.c
@@ -1,7 +1,7 @@
 /*
 htop - SolarisProcess.c
 (C) 2015 Hisham H. Muhammad
-(C) 2017 Guy M. Broome
+(C) 2017,2018 Guy M. Broome
 Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */

--- a/solaris/SolarisProcess.c
+++ b/solaris/SolarisProcess.c
@@ -34,10 +34,10 @@ typedef enum SolarisProcessFields {
 
 
 typedef struct SolarisProcess_ {
-   Process super;
-   int   kernel;
+   Process    super;
+   int        kernel;
    zoneid_t   zoneid;
-   char  zname[ZONENAME_MAX+1];
+   char*      zname;
    taskid_t   taskid;
    projid_t   projid;
    poolid_t   poolid;

--- a/solaris/SolarisProcess.h
+++ b/solaris/SolarisProcess.h
@@ -26,10 +26,10 @@ typedef enum SolarisProcessFields {
 
 
 typedef struct SolarisProcess_ {
-   Process super;
-   int   kernel;
+   Process    super;
+   int        kernel;
    zoneid_t   zoneid;
-   char  zname[ZONENAME_MAX+1];
+   char*      zname;
    taskid_t   taskid;
    projid_t   projid;
    poolid_t   poolid;

--- a/solaris/SolarisProcess.h
+++ b/solaris/SolarisProcess.h
@@ -5,7 +5,7 @@
 /*
 htop - SolarisProcess.h
 (C) 2015 Hisham H. Muhammad
-(C) 2017 Guy M. Broome
+(C) 2017,2018 Guy M. Broome
 Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -62,16 +62,6 @@ typedef struct SolarisProcessList_ {
 
 }*/
 
-static void setCommand(Process* process, const char* command, int len) {
-   if (process->comm && process->commLen >= len) {
-      strncpy(process->comm, command, len + 1);
-   } else {
-      free(process->comm);
-      process->comm = xStrdup(command);
-   }
-   process->commLen = len;
-}
-
 char* SolarisProcessList_readZoneName(kstat_ctl_t* kd, SolarisProcess* sproc) {
   char* zname;
   if ( sproc->zoneid == 0 ) {
@@ -326,7 +316,8 @@ void ProcessList_goThroughEntries(ProcessList* this) {
          proc->user            = UsersTable_getRef(this->usersTable, proc->st_uid);
          proc->nlwp            = _psinfo.pr_nlwp;
          proc->session         = _pstatus.pr_sid;
-         setCommand(proc,_psinfo.pr_fname,PRFNSZ);
+         proc->comm            = xStrdup(_psinfo.pr_fname);
+         proc->commLen         = strnlen(_psinfo.pr_fname,PRFNSZ); 
          sproc->zname          = SolarisProcessList_readZoneName(spl->kd,sproc);
          proc->majflt          = _prusage.pr_majf;
          proc->minflt          = _prusage.pr_minf; 
@@ -355,7 +346,8 @@ void ProcessList_goThroughEntries(ProcessList* this) {
          proc->pgrp            = _psinfo.pr_pgid;
          proc->nlwp            = _psinfo.pr_nlwp;
          proc->user            = UsersTable_getRef(this->usersTable, proc->st_uid);
-         setCommand(proc,_psinfo.pr_fname,PRFNSZ);
+	 proc->comm            = xStrdup(_psinfo.pr_fname);
+         proc->commLen         = strnlen(_psinfo.pr_fname,PRFNSZ);
          sproc->zname          = SolarisProcessList_readZoneName(spl->kd,sproc);
          proc->majflt          = _prusage.pr_majf;
          proc->minflt          = _prusage.pr_minf;

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -1,7 +1,7 @@
 /*
 htop - SolarisProcessList.c
 (C) 2014 Hisham H. Muhammad
-(C) 2017 Guy M. Broome
+(C) 2017,2018 Guy M. Broome
 Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -346,7 +346,7 @@ void ProcessList_goThroughEntries(ProcessList* this) {
          proc->pgrp            = _psinfo.pr_pgid;
          proc->nlwp            = _psinfo.pr_nlwp;
          proc->user            = UsersTable_getRef(this->usersTable, proc->st_uid);
-	 proc->comm            = xStrdup(_psinfo.pr_fname);
+         proc->comm            = xStrdup(_psinfo.pr_fname);
          proc->commLen         = strnlen(_psinfo.pr_fname,PRFNSZ);
          sproc->zname          = SolarisProcessList_readZoneName(spl->kd,sproc);
          proc->majflt          = _prusage.pr_majf;

--- a/solaris/SolarisProcessList.h
+++ b/solaris/SolarisProcessList.h
@@ -5,7 +5,7 @@
 /*
 htop - SolarisProcessList.h
 (C) 2014 Hisham H. Muhammad
-(C) 2017 Guy M. Broome
+(C) 2017,2018 Guy M. Broome
 Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */

--- a/solaris/SolarisProcessList.h
+++ b/solaris/SolarisProcessList.h
@@ -15,7 +15,7 @@ in the source distribution for its full text.
 
 #include <kstat.h>
 #include <sys/param.h>
-#include <sys/zone.h>
+#include <zone.h>
 #include <sys/uio.h>
 #include <sys/resource.h>
 #include <sys/sysconf.h>
@@ -44,10 +44,14 @@ typedef struct SolarisProcessList_ {
    CPUData* cpus;
 } SolarisProcessList;
 
+
+char* SolarisProcessList_readZoneName(kstat_ctl_t* kd, SolarisProcess* sproc);
+
 ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, uid_t userId);
 
 void ProcessList_delete(ProcessList* this);
 
 void ProcessList_goThroughEntries(ProcessList* this);
+
 
 #endif


### PR DESCRIPTION
Added proper backtrace on abort, plus linking against libmalloc - a simple thing that I should have seen earlier, which solves quite a few crashes.  Small pull, major improvement.