### PR TITLE
Use AM_CFLAGS and AM_LDFLAGS in Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -12,8 +12,8 @@ applications_DATA = htop.desktop
 pixmapdir = $(datadir)/pixmaps
 pixmap_DATA = htop.png
 
-htop_CFLAGS = -pedantic -Wall $(wextra_flag) -std=c99 -D_XOPEN_SOURCE_EXTENDED -DSYSCONFDIR=\"$(sysconfdir)\" -I"$(top_srcdir)/$(my_htop_platform)"
-htop_LDFLAGS = 
+AM_CFLAGS = -pedantic -Wall $(wextra_flag) -std=c99 -D_XOPEN_SOURCE_EXTENDED -DSYSCONFDIR=\"$(sysconfdir)\" -I"$(top_srcdir)/$(my_htop_platform)"
+AM_LDFLAGS =
 AM_CPPFLAGS = -DNDEBUG
 
 myhtopsources = AvailableMetersPanel.c CategoriesPanel.c CheckItem.c \
@@ -37,7 +37,7 @@ AffinityPanel.h HostnameMeter.h OpenFilesScreen.h Affinity.h IncSet.h Action.h \
 EnvScreen.h InfoScreen.h XAlloc.h
 
 if HTOP_LINUX
-htop_CFLAGS += -rdynamic 
+AM_CFLAGS += -rdynamic
 myhtopplatsources = linux/Platform.c linux/IOPriorityPanel.c linux/IOPriority.c \
 linux/LinuxProcess.c linux/LinuxProcessList.c linux/LinuxCRT.c linux/Battery.c
 
@@ -54,7 +54,7 @@ freebsd/FreeBSDProcess.h freebsd/FreeBSDCRT.h freebsd/Battery.h
 endif
 
 if HTOP_DRAGONFLYBSD
-htop_LDFLAGS += -lkvm -lkinfo -lexecinfo
+AM_LDFLAGS += -lkvm -lkinfo -lexecinfo
 myhtopplatsources = dragonflybsd/Platform.c dragonflybsd/DragonFlyBSDProcessList.c \
 dragonflybsd/DragonFlyBSDProcess.c dragonflybsd/DragonFlyBSDCRT.c dragonflybsd/Battery.c
 
@@ -71,7 +71,7 @@ openbsd/OpenBSDProcess.h openbsd/OpenBSDCRT.h openbsd/Battery.h
 endif
 
 if HTOP_DARWIN
-htop_LDFLAGS += -framework IOKit -framework CoreFoundation
+AM_LDFLAGS += -framework IOKit -framework CoreFoundation
 myhtopplatsources = darwin/Platform.c darwin/DarwinProcess.c \
 darwin/DarwinProcessList.c darwin/DarwinCRT.c darwin/Battery.c
 


### PR DESCRIPTION
This reduces generated Makefile.in size by 74%.
(217319 bytes -> 56326 bytes)

Automake considers that `<prog>_CFLAGS` and `<prog>_LDFLAGS` are
program-specific build rules, and when such are specified, Automake
will generate additional code just to avoid the "generic" and
package-wide AM_CFLAGS or AM_LDFLAGS. (Especially for `<prog>_CFLAGS`,
Automake will rename generated object files to become "prog-foo.o" and
such, and it's _a lot_ of code to achieve this in Makefile.)

There's no reason for htop to rename intermediate object files. It's
better to make things simpler.