### PR TITLE
Solaris: Implement LWP enumeration

### DIFF
--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -146,8 +146,19 @@ void Platform_getLoadAverage(double* one, double* five, double* fifteen) {
 }
 
 int Platform_getMaxPid() {
-// With LWP support enabled, we have to simulate a unique thread ID
-     return 99999999;
+   kstat_ctl_t *kc = NULL;
+   kstat_t *kshandle = NULL;
+   kvar_t *ksvar = NULL;
+   int vproc = 32778; // Reasonable Solaris default
+   kc = kstat_open();
+   if (kc != NULL) { kshandle = kstat_lookup(kc,"unix",0,"var"); }
+   if (kshandle != NULL) { kstat_read(kc,kshandle,NULL); }
+   ksvar = kshandle->ks_data;
+   if (ksvar->v_proc > 0 ) {
+      vproc = ksvar->v_proc;
+   }
+   if (kc != NULL) { kstat_close(kc); }
+   return vproc; 
 }
 
 double Platform_setCPUValues(Meter* this, int cpu) {

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -94,7 +94,7 @@ const SignalItem Platform_signals[] = {
 
 const unsigned int Platform_numberOfSignals = sizeof(Platform_signals)/sizeof(SignalItem);
 
-ProcessField Platform_defaultFields[] = { PID, USER, PRIORITY, NICE, M_SIZE, M_RESIDENT, STATE, PERCENT_CPU, PERCENT_MEM, TIME, COMM, 0 };
+ProcessField Platform_defaultFields[] = { PID, LWPID, USER, PRIORITY, NICE, M_SIZE, M_RESIDENT, STATE, PERCENT_CPU, PERCENT_MEM, TIME, COMM, 0 };
 
 MeterClass* Platform_meterTypes[] = {
    &CPUMeter_class,

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -146,19 +146,8 @@ void Platform_getLoadAverage(double* one, double* five, double* fifteen) {
 }
 
 int Platform_getMaxPid() {
-   kstat_ctl_t *kc = NULL;
-   kstat_t *kshandle = NULL;
-   kvar_t *ksvar = NULL;
-   int vproc = 32778; // Reasonable Solaris default
-   kc = kstat_open();
-   if (kc != NULL) { kshandle = kstat_lookup(kc,"unix",0,"var"); }
-   if (kshandle != NULL) { kstat_read(kc,kshandle,NULL); }
-   ksvar = kshandle->ks_data;
-   if (ksvar->v_proc > 0 ) {
-      vproc = ksvar->v_proc;
-   }
-   if (kc != NULL) { kstat_close(kc); }
-   return vproc; 
+// With LWP support enabled, we have to simulate a unique thread ID
+     return 99999999;
 }
 
 double Platform_setCPUValues(Meter* this, int cpu) {

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -35,7 +35,10 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "SignalsPanel.h"
+#include <signal.h>
 #include <sys/mkdev.h>
+
+#define  kill(pid, signal) kill(pid >> 10, signal)
 
 extern ProcessFieldData Process_fields[];
 typedef struct var kvar_t;

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -38,7 +38,7 @@ in the source distribution for its full text.
 #include <signal.h>
 #include <sys/mkdev.h>
 
-#define  kill(pid, signal) kill(pid >> 10, signal)
+#define  kill(pid, signal) kill(pid / 1024, signal)
 
 extern ProcessFieldData Process_fields[];
 typedef struct var kvar_t;

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -14,7 +14,10 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "SignalsPanel.h"
+#include <signal.h>
 #include <sys/mkdev.h>
+
+#define  kill(pid, signal) kill(pid >> 10, signal)
 
 extern ProcessFieldData Process_fields[];
 typedef struct var kvar_t;

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -17,7 +17,7 @@ in the source distribution for its full text.
 #include <signal.h>
 #include <sys/mkdev.h>
 
-#define  kill(pid, signal) kill(pid >> 10, signal)
+#define  kill(pid, signal) kill(pid / 1024, signal)
 
 extern ProcessFieldData Process_fields[];
 typedef struct var kvar_t;

--- a/solaris/SolarisProcess.c
+++ b/solaris/SolarisProcess.c
@@ -157,7 +157,13 @@ void SolarisProcess_writeField(Process* this, RichString* str, ProcessField fiel
    }
    case PID: xSnprintf(buffer, n, Process_pidFormat, sp->realpid); break;
    case PPID: xSnprintf(buffer, n, Process_pidFormat, sp->realppid); break;
-   case LWPID: xSnprintf(buffer, n, Process_pidFormat, sp->lwpid); break;
+   case LWPID:{
+      if (sp->lwpid <= 0) {
+         xSnprintf(buffer, n, "    - ");   
+      } else {
+         xSnprintf(buffer, n, Process_pidFormat, sp->lwpid); break;
+      }
+   }; break;
    default:
       Process_writeField(this, str, field);
       return;

--- a/solaris/SolarisProcess.c
+++ b/solaris/SolarisProcess.c
@@ -29,7 +29,8 @@ typedef enum SolarisProcessFields {
    TASKID = 103,
    POOLID = 104,
    CONTID = 105,
-   LAST_PROCESSFIELD = 106,
+   LWPID = 106,
+   LAST_PROCESSFIELD = 107,
 } SolarisProcessField;
 
 
@@ -42,6 +43,10 @@ typedef struct SolarisProcess_ {
    projid_t   projid;
    poolid_t   poolid;
    ctid_t     contid;
+   bool       is_lwp;
+   pid_t      realpid;
+   pid_t      realppid;
+   pid_t      lwpid;
 } SolarisProcess;
 
 
@@ -67,7 +72,7 @@ ProcessClass SolarisProcess_class = {
 
 ProcessFieldData Process_fields[] = {
    [0] = { .name = "", .title = NULL, .description = NULL, .flags = 0, },
-   [PID] = { .name = "PID", .title = "    PID ", .description = "Process/thread ID", .flags = 0, },
+   [PID] = { .name = "PID", .title = "    PID    ", .description = "Process/thread ID", .flags = 0, },
    [COMM] = { .name = "Command", .title = "Command ", .description = "Command line", .flags = 0, },
    [STATE] = { .name = "STATE", .title = "S ", .description = "Process state (S sleeping, R running, D disk, Z zombie, T traced, W paging)", .flags = 0, },
    [PPID] = { .name = "PPID", .title = "   PPID ", .description = "Parent process ID", .flags = 0, },
@@ -96,6 +101,7 @@ ProcessFieldData Process_fields[] = {
    [TASKID] = { .name = "TASKID", .title = " TSKID ", .description = "Task ID", .flags = 0, },
    [POOLID] = { .name = "POOLID", .title = " POLID ", .description = "Pool ID", .flags = 0, },
    [CONTID] = { .name = "CONTID", .title = " CNTID ", .description = "Contract ID", .flags = 0, },
+   [LWPID] = { .name = "LWPID", .title = " LWPID ", .description = "LWP ID", .flags = 0, },
    [LAST_PROCESSFIELD] = { .name = "*** report bug! ***", .title = NULL, .description = NULL, .flags = 0, },
 };
 
@@ -107,6 +113,7 @@ ProcessPidColumn Process_pidColumns[] = {
    { .id = CONTID, .label = "CNTID" },
    { .id = PID, .label = "PID" },
    { .id = PPID, .label = "PPID" },
+   { .id = LWPID, .label = "LWPID" },
    { .id = TPGID, .label = "TPGID" },
    { .id = TGID, .label = "TGID" },
    { .id = PGRP, .label = "PGRP" },
@@ -148,6 +155,9 @@ void SolarisProcess_writeField(Process* this, RichString* str, ProcessField fiel
       }
       break;
    }
+   case PID: xSnprintf(buffer, n, Process_pidFormat, sp->realpid); break;
+   case PPID: xSnprintf(buffer, n, Process_pidFormat, sp->realppid); break;
+   case LWPID: xSnprintf(buffer, n, Process_pidFormat, sp->lwpid); break;
    default:
       Process_writeField(this, str, field);
       return;
@@ -178,6 +188,12 @@ long SolarisProcess_compare(const void* v1, const void* v2) {
       return (p1->contid - p2->contid);
    case ZONE:
       return strcmp(p1->zname ? p1->zname : "global", p2->zname ? p2->zname : "global");
+   case PID:
+      return (p1->realpid - p2->realpid);
+   case PPID:
+      return (p1->realppid - p2->realppid);
+   case LWPID:
+      return (p1->lwpid - p2->lwpid);
    default:
       return Process_compare(v1, v2);
    }
@@ -186,8 +202,11 @@ long SolarisProcess_compare(const void* v1, const void* v2) {
 bool Process_isThread(Process* this) {
    SolarisProcess* fp = (SolarisProcess*) this;
 
-   if (fp->kernel == 1 )
+   if (fp->kernel == 1 ) {
       return 1;
-   else
+   } else if (fp->is_lwp) {
+      return 1;
+   } else {
       return 0;
+   }
 }

--- a/solaris/SolarisProcess.h
+++ b/solaris/SolarisProcess.h
@@ -21,7 +21,8 @@ typedef enum SolarisProcessFields {
    TASKID = 103,
    POOLID = 104,
    CONTID = 105,
-   LAST_PROCESSFIELD = 106,
+   LWPID = 106,
+   LAST_PROCESSFIELD = 107,
 } SolarisProcessField;
 
 
@@ -34,6 +35,10 @@ typedef struct SolarisProcess_ {
    projid_t   projid;
    poolid_t   poolid;
    ctid_t     contid;
+   bool       is_lwp;
+   pid_t      realpid;
+   pid_t      realppid;
+   pid_t      lwpid;
 } SolarisProcess;
 
 

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -434,8 +434,6 @@ void ProcessList_goThroughEntries(ProcessList* this) {
       fclose(fp);
       sproc->is_lwp = FALSE;
 
-      double kb_per_page = ((double)PAGE_SIZE / (double)1024.0);
-
       if(!preExisting) {
          // Fake PID values used for sorting, since Solaris LWPs lack unique PIDs
          proc->pid             = (_psinfo.pr_pid * 1024);
@@ -462,8 +460,8 @@ void ProcessList_goThroughEntries(ProcessList* this) {
          sproc->zname          = SolarisProcessList_readZoneName(spl->kd,sproc);
          proc->majflt          = _prusage.pr_majf;
          proc->minflt          = _prusage.pr_minf; 
-         proc->m_resident      = (long)(((double)_psinfo.pr_rssize)/kb_per_page);
-         proc->m_size          = (long)(((double)_psinfo.pr_size)/kb_per_page);
+         proc->m_resident      = _psinfo.pr_rssize/PAGE_SIZE_KB;
+         proc->m_size          = _psinfo.pr_size/PAGE_SIZE_KB;
          proc->priority        = _psinfo.pr_lwp.pr_pri;
          proc->nice            = _psinfo.pr_lwp.pr_nice;
          proc->processor       = _psinfo.pr_lwp.pr_onpro;
@@ -500,8 +498,8 @@ void ProcessList_goThroughEntries(ProcessList* this) {
          sproc->zname          = SolarisProcessList_readZoneName(spl->kd,sproc);
          proc->majflt          = _prusage.pr_majf;
          proc->minflt          = _prusage.pr_minf;
-         proc->m_resident      = (long)(((double)_psinfo.pr_rssize)/kb_per_page); 
-         proc->m_size          = (long)(((double)_psinfo.pr_size)/kb_per_page); 
+         proc->m_resident      = _psinfo.pr_rssize/PAGE_SIZE_KB; 
+         proc->m_size          = _psinfo.pr_size/PAGE_SIZE_KB; 
          proc->priority        = _psinfo.pr_lwp.pr_pri;
          proc->nice            = _psinfo.pr_lwp.pr_nice;
          proc->processor       = _psinfo.pr_lwp.pr_onpro;

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -253,7 +253,7 @@ void ProcessList_enumerateLWPs(Process* proc, char* name, ProcessList* pl, struc
    char lwpdir[MAX_NAME+1];
    DIR* dir = NULL;
    FILE* fp = NULL;
-   int lwpid;
+   pid_t lwpid;
    bool preExisting = false;   
    char filename[MAX_NAME+1];
    lwpsinfo_t _lwpsinfo;
@@ -268,7 +268,7 @@ void ProcessList_enumerateLWPs(Process* proc, char* name, ProcessList* pl, struc
    if (!dir) return;
    while ((entry = readdir(dir)) != NULL) {
       lwpname = entry->d_name;
-      lwpid   = (proc->pid << 10) + atoi(lwpname);
+      lwpid   = proc->pid + atoi(lwpname);
       lwp     = ProcessList_getProcess(pl, lwpid, &preExisting, (Process_New) SolarisProcess_new);
       slwp    = (SolarisProcess*) lwp;
       xSnprintf(filename, MAX_NAME, "%s/%s/lwp/%s/lwpsinfo", PROCDIR, name, lwpname);
@@ -438,9 +438,9 @@ void ProcessList_goThroughEntries(ProcessList* this) {
 
       if(!preExisting) {
          // Fake PID values used for sorting, since Solaris LWPs lack unique PIDs
-         proc->pid             = (_psinfo.pr_pid << 10);
-         proc->ppid            = (_psinfo.pr_ppid << 10);
-         proc->tgid            = (_psinfo.pr_ppid << 10);
+         proc->pid             = (_psinfo.pr_pid * 1024);
+         proc->ppid            = (_psinfo.pr_ppid * 1024); 
+         proc->tgid            = (_psinfo.pr_ppid * 1024);
          // Corresponding real values used for display
          sproc->realpid        = _psinfo.pr_pid;
          sproc->realppid       = _psinfo.pr_ppid;
@@ -483,8 +483,8 @@ void ProcessList_goThroughEntries(ProcessList* this) {
          strftime(proc->starttime_show, 7, ((proc->starttime_ctime > tv.tv_sec - 86400) ? "%R " : "%b%d "), &date); 
          ProcessList_add(this, proc);
       } else {
-         proc->ppid            = (_psinfo.pr_ppid << 10);
-         proc->tgid            = (_psinfo.pr_ppid << 10);
+         proc->ppid            = (_psinfo.pr_ppid * 1024);
+         proc->tgid            = (_psinfo.pr_ppid * 1024);
          sproc->realppid       = _psinfo.pr_ppid;
          sproc->lwpid          = 0; 
          sproc->zoneid         = _psinfo.pr_zoneid;

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -390,7 +390,6 @@ void ProcessList_goThroughEntries(ProcessList* this) {
    int    pid;
    bool   preExisting = false;
    Process* proc = NULL;
-   Process* parent = NULL;
    SolarisProcess* sproc = NULL;
    psinfo_t _psinfo;
    pstatus_t _pstatus;
@@ -416,7 +415,6 @@ void ProcessList_goThroughEntries(ProcessList* this) {
       name = entry->d_name;
       pid = atoi(name);
       proc = ProcessList_getProcess(this, pid, &preExisting, (Process_New) SolarisProcess_new);
-      proc->tgid = parent ? parent->pid : pid;
       sproc = (SolarisProcess *) proc;
       xSnprintf(filename, MAX_NAME, "%s/%s/psinfo", PROCDIR, name);
       fp = fopen(filename, "r");

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -268,6 +268,8 @@ void ProcessList_enumerateLWPs(Process* proc, char* name, ProcessList* pl, struc
    if (!dir) return;
    while ((entry = readdir(dir)) != NULL) {
       lwpname = entry->d_name;
+      // With 10 bits to spare, we can only list up to 1023 unique LWPs per process
+      if (atoi(lwpname) > 1023) break;
       lwpid   = proc->pid + atoi(lwpname);
       lwp     = ProcessList_getProcess(pl, lwpid, &preExisting, (Process_New) SolarisProcess_new);
       slwp    = (SolarisProcess*) lwp;

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -257,13 +257,11 @@ void ProcessList_enumerateLWPs(Process* proc, char* name, ProcessList* pl, struc
    bool preExisting = false;   
    char filename[MAX_NAME+1];
    lwpsinfo_t _lwpsinfo;
-   lwpstatus_t _lwpstatus;
    prusage_t _lwprusage;
    struct tm date;
    xSnprintf(lwpdir, MAX_NAME, "%s/%s/lwp", PROCDIR, name);
    struct dirent* entry;
    char* lwpname;
-   bool haveStatus = false;
    bool haveUsage = false;
 
    dir = opendir(lwpdir);
@@ -278,13 +276,6 @@ void ProcessList_enumerateLWPs(Process* proc, char* name, ProcessList* pl, struc
       if ( fp == NULL ) continue;
       fread(&_lwpsinfo,sizeof(lwpsinfo_t),1,fp);
       fclose(fp);
-      xSnprintf(filename, MAX_NAME, "%s/%s/lwp/%s/lwpstatus", PROCDIR, name, lwpname);
-      fp   = fopen(filename, "r");
-      if ( fp != NULL ) {
-         haveStatus = true;
-         fread(&_lwpstatus,sizeof(lwpstatus_t),1,fp);
-         fclose(fp);
-      }
       xSnprintf(filename, MAX_NAME, "%s/%s/lwp/%s/lwpusage", PROCDIR, name, lwpname);
       fp   = fopen(filename, "r");
       if ( fp != NULL ) {

--- a/solaris/SolarisProcessList.h
+++ b/solaris/SolarisProcessList.h
@@ -51,6 +51,8 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, ui
 
 void ProcessList_delete(ProcessList* this);
 
+void ProcessList_enumerateLWPs(Process* proc, char* name, ProcessList* pl, struct timeval tv);
+
 void ProcessList_goThroughEntries(ProcessList* this);
 
 


### PR DESCRIPTION
Since Solaris does not have system-wide unique identifiers per LWP, this change required creating a "virtual PID" for ProcessList, while maintaining the real PIDs and LWPIDs discretely per-process for display.  This change adds the new default LWPID column for Solaris.  Shadowing kill() in solaris/Platform.h was also needed to account for the virtual PIDs. 