### PR TITLE
MakeHeader.py: Fix for non-utf8 environments

### DIFF
--- a/scripts/MakeHeader.py
+++ b/scripts/MakeHeader.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python
-import os, sys, string
+import os, sys, string, io
 try:
-   from cStringIO import StringIO
+   from StringIO import StringIO
 except ImportError:
-   try:
-      from StringIO import StringIO
-   except ImportError:
-      from io import StringIO
+   from io import StringIO
 
 ANY=1
 COPY=2
@@ -16,7 +13,7 @@ SKIPONE=4
 state = ANY
 static = 0
 
-file = open(sys.argv[1])
+file = io.open(sys.argv[1], "r", encoding="utf-8")
 name = sys.argv[1][:-2]
 
 out = StringIO()
@@ -94,12 +91,12 @@ out.write( "#endif\n" )
 # This prevents a lot of recompilation during development
 out.seek(0)
 try:
-   with open(name + ".h", "r") as orig:
+   with io.open(name + ".h", "r", encoding="utf-8") as orig:
       origcontents = orig.readlines()
 except:
    origcontents = ""
 if origcontents != out.readlines():
-   with open(name + ".h", "w") as new:
+   with io.open(name + ".h", "w", encoding="utf-8") as new:
       print("Writing "+name+".h")
       new.write(out.getvalue())
 out.close()


### PR DESCRIPTION
Header creation fails with non-utf8 locale and python3.
Simply set LC_ALL="C" and use python3 to reproduce the issue.

env LC_ALL="C" ./scripts/MakeHeader.py MetersPanel.c
Traceback (most recent call last):
  File "./scripts/MakeHeader.py", line 32, in <module>
    for line in file.readlines():
  File "/usr/lib64/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 956: ordinal not in range(128)

This changes is python2 and python3 compatible

cStringIO.StringIO module is removed because it is not able to accept unicode strings
https://docs.python.org/2/library/stringio.html#cStringIO.StringIO