### PR TITLE
Solaris: misc. fixes. improvements, and cleanup

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -243,6 +243,7 @@ fi
 
 if test "$my_htop_platform" = "solaris"; then
    AC_CHECK_LIB([kstat], [kstat_open], [], [missing_libraries="$missing_libraries libkstat"])
+   AC_CHECK_LIB([proc], [Pgrab_error], [], [missing_libraries="$missing_libraries libproc"])
    AC_CHECK_LIB([malloc], [free], [], [missing_libraries="$missing_libraries libmalloc"])
 fi
 

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -213,5 +213,5 @@ void Platform_setSwapValues(Meter* this) {
 
 char* Platform_getProcessEnv(pid_t pid) {
    (void) pid;
-   return NULL;
+   return "Not (yet) supported on Solaris.  Sorry!";
 }

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -37,11 +37,20 @@ in the source distribution for its full text.
 #include "SignalsPanel.h"
 #include <signal.h>
 #include <sys/mkdev.h>
+#include <sys/proc.h>
+#include <libproc.h>
 
 #define  kill(pid, signal) kill(pid / 1024, signal)
 
 extern ProcessFieldData Process_fields[];
 typedef struct var kvar_t;
+
+typedef struct envAccum_ {
+   size_t capacity;
+   size_t size;
+   size_t bytes; 
+   char *env;
+} envAccum;
 
 }*/
 
@@ -211,7 +220,38 @@ void Platform_setSwapValues(Meter* this) {
    this->values[0] = pl->usedSwap;
 }
 
+static int Platform_buildenv(void *accum, struct ps_prochandle *Phandle, uintptr_t addr, const char *str) {
+   envAccum *accump = accum;
+   (void) Phandle;
+   (void) addr; 
+   size_t thissz = strlen(str);
+   if ((thissz + 2) > (accump->capacity - accump->size))
+      accump->env = xRealloc(accump->env, accump->capacity *= 2);
+   if ((thissz + 2) > (accump->capacity - accump->size))
+      return 1;
+   strlcpy( accump->env + accump->size, str, (accump->capacity - accump->size));
+   strncpy( accump->env + accump->size + thissz + 1, "\n", 1);
+   accump->size = accump->size + thissz + 1;
+   return 0; 
+}
+
 char* Platform_getProcessEnv(pid_t pid) {
-   (void) pid;
-   return "Not (yet) supported on Solaris.  Sorry!";
+   envAccum envBuilder;
+   pid_t realpid = pid / 1024;
+   int graberr;
+   struct ps_prochandle *Phandle;
+   
+   if ((Phandle = Pgrab(realpid,PGRAB_RDONLY,&graberr)) == NULL)
+      return "Unable to read process environment.";
+
+   envBuilder.capacity = 4096;
+   envBuilder.size     = 0;
+   envBuilder.env      = xMalloc(envBuilder.capacity);
+
+   (void) Penv_iter(Phandle,Platform_buildenv,&envBuilder); 
+
+   Prelease(Phandle, 0);
+
+   strncpy( envBuilder.env + envBuilder.size + 1, "\0", 1);
+   return envBuilder.env;
 }

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -252,6 +252,6 @@ char* Platform_getProcessEnv(pid_t pid) {
 
    Prelease(Phandle, 0);
 
-   strncpy( envBuilder.env + envBuilder.size + 1, "\0", 1);
+   strncpy( envBuilder.env + envBuilder.size, "\0", 1);
    return envBuilder.env;
 }

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -2,7 +2,7 @@
 htop - solaris/Platform.c
 (C) 2014 Hisham H. Muhammad
 (C) 2015 David C. Hunt
-(C) 2017 Guy M. Broome
+(C) 2017,2018 Guy M. Broome
 Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -16,11 +16,20 @@ in the source distribution for its full text.
 #include "SignalsPanel.h"
 #include <signal.h>
 #include <sys/mkdev.h>
+#include <sys/proc.h>
+#include <libproc.h>
 
 #define  kill(pid, signal) kill(pid / 1024, signal)
 
 extern ProcessFieldData Process_fields[];
 typedef struct var kvar_t;
+
+typedef struct envAccum_ {
+   size_t capacity;
+   size_t size;
+   size_t bytes; 
+   char *env;
+} envAccum;
 
 
 extern double plat_loadavg[3];

--- a/solaris/Platform.h
+++ b/solaris/Platform.h
@@ -6,7 +6,7 @@
 htop - solaris/Platform.h
 (C) 2014 Hisham H. Muhammad
 (C) 2015 David C. Hunt
-(C) 2017 Guy M. Broome
+(C) 2017,2018 Guy M. Broome
 Released under the GNU GPL, see the COPYING file
 in the source distribution for its full text.
 */

--- a/solaris/SolarisProcess.c
+++ b/solaris/SolarisProcess.c
@@ -76,7 +76,7 @@ ProcessFieldData Process_fields[] = {
    [0] = { .name = "", .title = NULL, .description = NULL, .flags = 0, },
    [PID] = { .name = "PID", .title = "    PID    ", .description = "Process/thread ID", .flags = 0, },
    [COMM] = { .name = "Command", .title = "Command ", .description = "Command line", .flags = 0, },
-   [STATE] = { .name = "STATE", .title = "S ", .description = "Process state (S sleeping, R running, D disk, Z zombie, T traced, W paging)", .flags = 0, },
+   [STATE] = { .name = "STATE", .title = "S ", .description = "Process state (S sleeping, R running, O onproc, Z zombie, T stopped, W waiting)", .flags = 0, },
    [PPID] = { .name = "PPID", .title = "   PPID ", .description = "Parent process ID", .flags = 0, },
    [PGRP] = { .name = "PGRP", .title = "   PGRP ", .description = "Process group ID", .flags = 0, },
    [SESSION] = { .name = "SESSION", .title = "    SID ", .description = "Process's session ID", .flags = 0, },

--- a/solaris/SolarisProcess.c
+++ b/solaris/SolarisProcess.c
@@ -159,13 +159,7 @@ void SolarisProcess_writeField(Process* this, RichString* str, ProcessField fiel
    }
    case PID: xSnprintf(buffer, n, Process_pidFormat, sp->realpid); break;
    case PPID: xSnprintf(buffer, n, Process_pidFormat, sp->realppid); break;
-   case LWPID:{
-      if (sp->lwpid <= 0) {
-         xSnprintf(buffer, n, "    - ");   
-      } else {
-         xSnprintf(buffer, n, Process_pidFormat, sp->lwpid); break;
-      }
-   }; break;
+   case LWPID: xSnprintf(buffer, n, Process_pidFormat, sp->lwpid); break;
    default:
       Process_writeField(this, str, field);
       return;

--- a/solaris/SolarisProcess.c
+++ b/solaris/SolarisProcess.c
@@ -131,10 +131,10 @@ SolarisProcess* SolarisProcess_new(Settings* settings) {
 }
 
 void Process_delete(Object* cast) {
-   SolarisProcess* this = (SolarisProcess*) cast;
+   SolarisProcess* sp = (SolarisProcess*) cast;
    Process_done((Process*)cast);
-   free(this->zname);
-   free(this);
+   free(sp->zname);
+   free(sp);
 }
 
 void SolarisProcess_writeField(Process* this, RichString* str, ProcessField field) {

--- a/solaris/SolarisProcess.c
+++ b/solaris/SolarisProcess.c
@@ -20,6 +20,8 @@ in the source distribution for its full text.
 /*{
 #include "Settings.h"
 #include <zone.h>
+#include <sys/proc.h>
+#include <libproc.h>
 
 typedef enum SolarisProcessFields {
    // Add platform-specific fields here, with ids >= 100

--- a/solaris/SolarisProcess.h
+++ b/solaris/SolarisProcess.h
@@ -12,6 +12,8 @@ in the source distribution for its full text.
 
 #include "Settings.h"
 #include <zone.h>
+#include <sys/proc.h>
+#include <libproc.h>
 
 typedef enum SolarisProcessFields {
    // Add platform-specific fields here, with ids >= 100

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -236,6 +236,12 @@ void ProcessList_delete(ProcessList* this) {
    free(this);
 }
 
+/* NOTE: the following is a callback function of type proc_walk_f
+ *       and MUST conform to the appropriate definition in order
+ *       to work.  See libproc(3LIB) on a Solaris or Illumos
+ *       system for more info.
+ */ 
+
 int SolarisProcessList_walkproc(psinfo_t *_psinfo, lwpsinfo_t *_lwpsinfo, void *listptr) {
    struct timeval tv;
    struct tm date;
@@ -319,7 +325,7 @@ int SolarisProcessList_walkproc(psinfo_t *_psinfo, lwpsinfo_t *_lwpsinfo, void *
       // See note above (in common section) about this BINARY FRACTION
       proc->percent_cpu     = ((uint16_t)_psinfo->pr_pctcpu/(double)32768)*(double)100.0;
       proc->time            = _psinfo->pr_time.tv_sec;
-      if(!preExisting) { // Tasks done only for NEW processes
+      if(!preExistingP) { // Tasks done only for NEW processes
          sproc->is_lwp = false;
          proc->starttime_ctime = _psinfo->pr_start.tv_sec;
       }
@@ -342,7 +348,7 @@ int SolarisProcessList_walkproc(psinfo_t *_psinfo, lwpsinfo_t *_lwpsinfo, void *
    } else { // We are not in the master LWP, so jump to the LWP handling code
       lwp->percent_cpu        = ((uint16_t)_lwpsinfo->pr_pctcpu/(double)32768)*(double)100.0;
       lwp->time               = _lwpsinfo->pr_time.tv_sec;
-      if (!preExisting) { // Tasks done only for NEW LWPs
+      if (!preExistingL) { // Tasks done only for NEW LWPs
          slwp->is_lwp         = true; 
          lwp->basenameOffset  = -1;
          lwp->ppid            = proc->pid;

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -278,12 +278,44 @@ void ProcessList_enumerateLWPs(Process* proc, char* name, ProcessList* pl, struc
          fread(&_lwprusage,sizeof(prusage_t),1,fp);
          fclose(fp);
       }
-      slwp->is_lwp = true;
 
+      // Common items set for both new and refreshed LWPs
+      slwp->zoneid            = sproc->zoneid;
+      lwp->percent_cpu        = ((uint16_t)_lwpsinfo.pr_pctcpu/(double)32768)*(double)100.0;
+      lwp->pgrp               = proc->pgrp;
+      lwp->st_uid             = proc->st_uid;
+      lwp->user               = UsersTable_getRef(pl->usersTable, lwp->st_uid);
+      lwp->session            = proc->session;
+      lwp->comm               = xStrdup(proc->comm);
+      lwp->commLen            = strnlen(proc->comm,PRFNSZ);
+      slwp->zname             = sproc->zname;
+      lwp->tty_nr             = proc->tty_nr;
+      if (haveUsage) {
+         lwp->majflt          = _lwprusage.pr_majf;
+         lwp->minflt          = _lwprusage.pr_minf;
+      } else {
+         lwp->majflt          = 0;
+         lwp->minflt          = 0;
+      }
+      lwp->priority           = _lwpsinfo.pr_pri;
+      lwp->nice               = _lwpsinfo.pr_nice;
+      lwp->processor          = _lwpsinfo.pr_onpro;
+      lwp->state              = _lwpsinfo.pr_sname;
+      lwp->time               = _lwpsinfo.pr_time.tv_sec;
+      slwp->taskid            = sproc->taskid;
+      slwp->projid            = sproc->projid;
+      slwp->poolid            = sproc->poolid;
+      slwp->contid            = sproc->contid;
+      lwp->show               = false;
+
+      // Tasks done only for NEW LWPs  
       if (!preExisting) {
+         slwp->is_lwp         = true; 
          lwp->basenameOffset  = -1;
          slwp->kernel         = sproc->kernel;
          // Fake values used for sorting
+         // Only set once because threads don't generally
+         // move... between... processes.
          lwp->pid             = lwpid;
          lwp->ppid            = proc->pid;
          lwp->tgid            = proc->pid;
@@ -291,79 +323,27 @@ void ProcessList_enumerateLWPs(Process* proc, char* name, ProcessList* pl, struc
          slwp->realpid        = sproc->realpid;
          slwp->realppid       = sproc->realpid;
          slwp->lwpid          = atoi(lwpname);
-         slwp->zoneid         = sproc->zoneid;
-         lwp->tty_nr          = proc->tty_nr;
-         lwp->pgrp            = proc->pgrp;
-         lwp->percent_cpu     = ((uint16_t)_lwpsinfo.pr_pctcpu/(double)32768)*(double)100.0;
          // Not tracked per thread
          lwp->percent_mem     = (double)0.0;
-         lwp->st_uid          = proc->st_uid;
-         lwp->user            = UsersTable_getRef(pl->usersTable, lwp->st_uid);
          lwp->nlwp            = 0;
-         lwp->session         = proc->session;
-         lwp->comm            = xStrdup(proc->comm);
-         lwp->commLen         = strnlen(proc->comm,PRFNSZ);
-         slwp->zname          = sproc->zname;
-         if (haveUsage) {
-            lwp->majflt       = _lwprusage.pr_majf;
-            lwp->minflt       = _lwprusage.pr_minf;
-         } else {
-            lwp->majflt       = 0;
-            lwp->minflt       = 0;
-         }
          lwp->m_resident      = 0;
          lwp->m_size          = 0;
-         lwp->priority        = _lwpsinfo.pr_pri;
-         lwp->nice            = _lwpsinfo.pr_nice;
-         lwp->processor       = _lwpsinfo.pr_onpro;
-         lwp->state           = _lwpsinfo.pr_sname;
-         lwp->time            = _lwpsinfo.pr_time.tv_sec;
-         slwp->taskid         = sproc->taskid;
-         slwp->projid         = sproc->projid;
-         slwp->poolid         = sproc->poolid;
-         slwp->contid         = sproc->contid;
          lwp->starttime_ctime = _lwpsinfo.pr_start.tv_sec;
          (void) localtime_r((time_t*) &lwp->starttime_ctime, &date);
          strftime(lwp->starttime_show, 7, ((lwp->starttime_ctime > tv.tv_sec - 86400) ? "%R " : "%b%d "), &date);
          ProcessList_add(pl, lwp);
-         lwp->show            = false;
-      } else {
-         slwp->zoneid         = sproc->zoneid;
-         lwp->pgrp            = proc->pgrp;
-         lwp->percent_cpu     = ((uint16_t)_lwpsinfo.pr_pctcpu/(double)32768)*(double)100.0;
-         // Not tracked per thread
-         lwp->percent_mem     = (double)0.0;
-         lwp->st_uid          = proc->st_uid;
-         lwp->user            = UsersTable_getRef(pl->usersTable, lwp->st_uid);
-         lwp->nlwp            = 0;
-         lwp->session         = proc->session;
-         lwp->comm            = xStrdup(proc->comm);
-         lwp->commLen         = strnlen(proc->comm,PRFNSZ);
-         slwp->zname          = sproc->zname;
-         if (haveUsage) {
-            lwp->majflt       = _lwprusage.pr_majf;
-            lwp->minflt       = _lwprusage.pr_minf;
-         }
-         lwp->m_resident      = 0;
-         lwp->m_size          = 0;
-         lwp->priority        = _lwpsinfo.pr_pri;
-         lwp->nice            = _lwpsinfo.pr_nice;
-         lwp->processor       = _lwpsinfo.pr_onpro;
-         lwp->state           = _lwpsinfo.pr_sname;
-         lwp->time            = _lwpsinfo.pr_time.tv_sec;
-         slwp->taskid         = sproc->taskid;
-         slwp->projid         = sproc->projid;
-         slwp->poolid         = sproc->poolid;
-         slwp->contid         = sproc->contid;
-         lwp->show            = false;
       }
+
       // Top-level process only gets this for the representative LWP
       if (lwp->state == 'O') proc->state = 'O';
       if (slwp->kernel  && !pl->settings->hideKernelThreads)   lwp->show = true;
       if (!slwp->kernel && !pl->settings->hideUserlandThreads) lwp->show = true;
       lwp->updated = true;
+
    }
+
    closedir(dir);
+
 }
 
 
@@ -415,45 +395,48 @@ void ProcessList_goThroughEntries(ProcessList* this) {
       if ( fp == NULL ) continue;
       fread(&_prusage,sizeof(prusage_t),1,fp);
       fclose(fp);
-      sproc->is_lwp = FALSE;
 
+      // Common items set for both new and refreshed processes
+      proc->ppid            = (_psinfo.pr_ppid * 1024);
+      proc->tgid            = (_psinfo.pr_ppid * 1024);
+      sproc->realppid       = _psinfo.pr_ppid;
+      sproc->zoneid         = _psinfo.pr_zoneid;
+      sproc->zname          = SolarisProcessList_readZoneName(spl->kd,sproc);
+      // NOTE: These 'percentages' are 16-bit BINARY FRACTIONS where 1.0 = 0x8000
+      // Source: https://docs.oracle.com/cd/E19253-01/816-5174/proc-4/index.html
+      // (accessed on 18 November 2017)
+      proc->percent_cpu     = ((uint16_t)_psinfo.pr_pctcpu/(double)32768)*(double)100.0;
+      proc->percent_mem     = ((uint16_t)_psinfo.pr_pctmem/(double)32768)*(double)100.0;
+      proc->st_uid          = _psinfo.pr_euid;
+      proc->user            = UsersTable_getRef(this->usersTable, proc->st_uid);
+      proc->pgrp            = _psinfo.pr_pgid;
+      proc->nlwp            = _psinfo.pr_nlwp;
+      proc->session         = _pstatus.pr_sid;
+      proc->comm            = xStrdup(_psinfo.pr_fname);
+      proc->commLen         = strnlen(_psinfo.pr_fname,PRFNSZ);
+      proc->tty_nr          = _psinfo.pr_ttydev;
+      proc->majflt          = _prusage.pr_majf;
+      proc->minflt          = _prusage.pr_minf;
+      proc->m_resident      = _psinfo.pr_rssize/PAGE_SIZE_KB;
+      proc->m_size          = _psinfo.pr_size/PAGE_SIZE_KB;
+      proc->priority        = _psinfo.pr_lwp.pr_pri;
+      proc->nice            = _psinfo.pr_lwp.pr_nice;
+      proc->processor       = _psinfo.pr_lwp.pr_onpro;
+      proc->state           = _psinfo.pr_lwp.pr_sname;
+      proc->time            = _psinfo.pr_time.tv_sec;
+      sproc->taskid         = _psinfo.pr_taskid;
+      sproc->projid         = _psinfo.pr_projid;
+      sproc->poolid         = _psinfo.pr_poolid;
+      sproc->contid         = _psinfo.pr_contract;
+         
+      // Tasks done only for NEW processes
       if(!preExisting) {
+         sproc->is_lwp = false;
          // Fake PID values used for sorting, since Solaris LWPs lack unique PIDs
          proc->pid             = (_psinfo.pr_pid * 1024);
-         proc->ppid            = (_psinfo.pr_ppid * 1024); 
-         proc->tgid            = (_psinfo.pr_ppid * 1024);
          // Corresponding real values used for display
          sproc->realpid        = _psinfo.pr_pid;
-         sproc->realppid       = _psinfo.pr_ppid;
-         sproc->lwpid          = 0; 
-         sproc->zoneid         = _psinfo.pr_zoneid;
-         proc->tty_nr          = _psinfo.pr_ttydev;
-         proc->pgrp            = _psinfo.pr_pgid;
-         // NOTE: These 'percentages' are 16-bit BINARY FRACTIONS where 1.0 = 0x8000
-         // Source: https://docs.oracle.com/cd/E19253-01/816-5174/proc-4/index.html
-         // (accessed on 18 November 2017)
-         proc->percent_cpu     = ((uint16_t)_psinfo.pr_pctcpu/(double)32768)*(double)100.0;
-         proc->percent_mem     = ((uint16_t)_psinfo.pr_pctmem/(double)32768)*(double)100.0;
-         proc->st_uid          = _psinfo.pr_euid;
-         proc->user            = UsersTable_getRef(this->usersTable, proc->st_uid);
-         proc->nlwp            = _psinfo.pr_nlwp;
-         proc->session         = _pstatus.pr_sid;
-         proc->comm            = xStrdup(_psinfo.pr_fname);
-         proc->commLen         = strnlen(_psinfo.pr_fname,PRFNSZ); 
-         sproc->zname          = SolarisProcessList_readZoneName(spl->kd,sproc);
-         proc->majflt          = _prusage.pr_majf;
-         proc->minflt          = _prusage.pr_minf; 
-         proc->m_resident      = _psinfo.pr_rssize/PAGE_SIZE_KB;
-         proc->m_size          = _psinfo.pr_size/PAGE_SIZE_KB;
-         proc->priority        = _psinfo.pr_lwp.pr_pri;
-         proc->nice            = _psinfo.pr_lwp.pr_nice;
-         proc->processor       = _psinfo.pr_lwp.pr_onpro;
-         proc->state           = _psinfo.pr_lwp.pr_sname;
-         proc->time            = _psinfo.pr_time.tv_sec;
-         sproc->taskid         = _psinfo.pr_taskid;
-         sproc->projid         = _psinfo.pr_projid;
-         sproc->poolid         = _psinfo.pr_poolid;
-         sproc->contid         = _psinfo.pr_contract;
+         sproc->lwpid          = 0;
          proc->starttime_ctime = _psinfo.pr_start.tv_sec;
          if ((sproc->realppid <= 0) && !(sproc->realpid <= 1)) {
             sproc->kernel = true;
@@ -461,37 +444,8 @@ void ProcessList_goThroughEntries(ProcessList* this) {
             sproc->kernel = false;
          }
          (void) localtime_r((time_t*) &proc->starttime_ctime, &date);
-         strftime(proc->starttime_show, 7, ((proc->starttime_ctime > tv.tv_sec - 86400) ? "%R " : "%b%d "), &date); 
+         strftime(proc->starttime_show, 7, ((proc->starttime_ctime > tv.tv_sec - 86400) ? "%R " : "%b%d "), &date);
          ProcessList_add(this, proc);
-      } else {
-         proc->ppid            = (_psinfo.pr_ppid * 1024);
-         proc->tgid            = (_psinfo.pr_ppid * 1024);
-         sproc->realppid       = _psinfo.pr_ppid;
-         sproc->lwpid          = 0; 
-         sproc->zoneid         = _psinfo.pr_zoneid;
-         // See note above about these percentages
-         proc->percent_cpu     = ((uint16_t)_psinfo.pr_pctcpu/(double)32768)*(double)100.0;
-         proc->percent_mem     = ((uint16_t)_psinfo.pr_pctmem/(double)32768)*(double)100.0;
-         proc->st_uid          = _psinfo.pr_euid;
-         proc->pgrp            = _psinfo.pr_pgid;
-         proc->nlwp            = _psinfo.pr_nlwp;
-         proc->user            = UsersTable_getRef(this->usersTable, proc->st_uid);
-         proc->comm            = xStrdup(_psinfo.pr_fname);
-         proc->commLen         = strnlen(_psinfo.pr_fname,PRFNSZ);
-         sproc->zname          = SolarisProcessList_readZoneName(spl->kd,sproc);
-         proc->majflt          = _prusage.pr_majf;
-         proc->minflt          = _prusage.pr_minf;
-         proc->m_resident      = _psinfo.pr_rssize/PAGE_SIZE_KB; 
-         proc->m_size          = _psinfo.pr_size/PAGE_SIZE_KB; 
-         proc->priority        = _psinfo.pr_lwp.pr_pri;
-         proc->nice            = _psinfo.pr_lwp.pr_nice;
-         proc->processor       = _psinfo.pr_lwp.pr_onpro;
-         proc->state           = _psinfo.pr_lwp.pr_sname;
-         proc->time            = _psinfo.pr_time.tv_sec;
-         sproc->taskid         = _psinfo.pr_taskid;
-         sproc->projid         = _psinfo.pr_projid;
-         sproc->poolid         = _psinfo.pr_poolid;
-         sproc->contid         = _psinfo.pr_contract;
       }
 
       if (proc->nlwp > 1) {

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -15,13 +15,11 @@ in the source distribution for its full text.
 #include <sys/types.h>
 #include <sys/user.h>
 #include <err.h>
-#include <fcntl.h>
 #include <limits.h>
 #include <string.h>
 #include <procfs.h>
 #include <errno.h>
 #include <pwd.h>
-#include <dirent.h>
 #include <math.h>
 #include <time.h>
 
@@ -238,139 +236,95 @@ void ProcessList_delete(ProcessList* this) {
    free(this);
 }
 
-void ProcessList_enumerateLWPs(Process* proc, ProcessList* pl, lwpsinfo_t *_lwpsinfo, struct timeval tv) {
-   Process *lwp;
-   SolarisProcess *slwp;
-   SolarisProcess *sproc = (SolarisProcess*) proc;
-   id_t lwpid_real; 
-   pid_t lwpid;
-   bool preExisting = false;   
-   struct tm date;
-
-   // With 10 bits to spare, we can only list up to 1023 unique LWPs per process
-   lwpid_real = _lwpsinfo->pr_lwpid;
-   if (lwpid_real > 1023) return;
-   lwpid   = proc->pid + lwpid_real;
-   lwp     = ProcessList_getProcess(pl, lwpid, &preExisting, (Process_New) SolarisProcess_new);
-   slwp    = (SolarisProcess*) lwp;
-
-   // Common items set for both new and refreshed LWPs
-   slwp->zoneid            = sproc->zoneid;
-   lwp->percent_cpu        = ((uint16_t)_lwpsinfo->pr_pctcpu/(double)32768)*(double)100.0;
-   lwp->pgrp               = proc->pgrp;
-   lwp->st_uid             = proc->st_uid;
-   lwp->user               = UsersTable_getRef(pl->usersTable, lwp->st_uid);
-   lwp->session            = proc->session;
-   lwp->comm               = xStrdup(proc->comm);
-   lwp->commLen            = strnlen(proc->comm,PRFNSZ);
-   slwp->zname             = sproc->zname;
-   lwp->tty_nr             = proc->tty_nr;
-   lwp->priority           = _lwpsinfo->pr_pri;
-   lwp->nice               = _lwpsinfo->pr_nice;
-   lwp->processor          = _lwpsinfo->pr_onpro;
-   lwp->state              = _lwpsinfo->pr_sname;
-   lwp->time               = _lwpsinfo->pr_time.tv_sec;
-   slwp->taskid            = sproc->taskid;
-   slwp->projid            = sproc->projid;
-   slwp->poolid            = sproc->poolid;
-   slwp->contid            = sproc->contid;
-   lwp->show               = false;
-
-   // Tasks done only for NEW LWPs  
-   if (!preExisting) {
-      slwp->is_lwp         = true; 
-      lwp->basenameOffset  = -1;
-      slwp->kernel         = sproc->kernel;
-      // Fake values used for sorting
-      // Only set once because threads don't generally
-      // move... between... processes.
-      lwp->pid             = lwpid;
-      lwp->ppid            = proc->pid;
-      lwp->tgid            = proc->pid;
-      // Corresponding real values used for display
-      slwp->realpid        = sproc->realpid;
-      slwp->realppid       = sproc->realpid;
-      slwp->lwpid          = lwpid_real;
-      // Not tracked per thread
-      lwp->percent_mem     = (double)0.0;
-      lwp->nlwp            = 0;
-      lwp->m_resident      = 0;
-      lwp->m_size          = 0;
-      lwp->starttime_ctime = _lwpsinfo->pr_start.tv_sec;
-      (void) localtime_r((time_t*) &lwp->starttime_ctime, &date);
-      strftime(lwp->starttime_show, 7, ((lwp->starttime_ctime > tv.tv_sec - 86400) ? "%R " : "%b%d "), &date);
-      ProcessList_add(pl, lwp);
-   }
-
-   // Top-level process only gets this for the representative LWP
-   if (lwp->state == 'O') proc->state = 'O';
-   if (slwp->kernel  && !pl->settings->hideKernelThreads)   lwp->show = true;
-   if (!slwp->kernel && !pl->settings->hideUserlandThreads) lwp->show = true;
-   lwp->updated = true;
-
-   return;
-}
-
 int SolarisProcessList_walkproc(psinfo_t *_psinfo, lwpsinfo_t *_lwpsinfo, void *listptr) {
-   ProcessList *pl = (ProcessList*) listptr;
-   SolarisProcessList *spl = (SolarisProcessList*) listptr;
-   bool preExisting = false;
-   Process *proc = ProcessList_getProcess(pl, _psinfo->pr_pid * 1024, &preExisting, (Process_New) SolarisProcess_new);
-   SolarisProcess *sproc = (SolarisProcess*) proc;
    struct timeval tv;
    struct tm date;
+   bool preExistingP = false;
+   bool preExistingL = false;
+   bool preExisting;
+   Process *cproc;
+   SolarisProcess *csproc;
 
-   // Are we on the representative LWP?
-   if (_lwpsinfo->pr_lwpid == _psinfo->pr_lwp.pr_lwpid) { 
-      // Common items set for both new and refreshed processes
+   // Setup process list
+   ProcessList *pl = (ProcessList*) listptr;
+   SolarisProcessList *spl = (SolarisProcessList*) listptr;
+
+   // Setup Process entry
+   Process *proc           = ProcessList_getProcess(pl, _psinfo->pr_pid * 1024, &preExistingP, (Process_New) SolarisProcess_new);
+   SolarisProcess *sproc   = (SolarisProcess*) proc;
+
+   // Setup LWP entry
+   id_t lwpid_real = _lwpsinfo->pr_lwpid;
+   if (lwpid_real > 1023) return 0;
+   pid_t lwpid   = proc->pid + lwpid_real;
+   Process *lwp            = ProcessList_getProcess(pl, lwpid, &preExistingL, (Process_New) SolarisProcess_new);
+   SolarisProcess *slwp    = (SolarisProcess*) lwp;
+
+   bool onMasterLWP = (_lwpsinfo->pr_lwpid == _psinfo->pr_lwp.pr_lwpid);
+
+   // Determine whether we're updating proc info or LWP info
+   // based on whether or not we're on the representative LWP
+   // for a given proc
+   if (onMasterLWP) {
+      cproc = proc;
+      csproc = sproc;
+      preExisting = preExistingP;
+   } else {
+      cproc = lwp;
+      csproc = slwp;
+      preExisting = preExistingL;
+   }
+
+   gettimeofday(&tv, NULL);
+
+   // Common code pass 1
+   csproc->zoneid           = _psinfo->pr_zoneid;
+   csproc->zname            = SolarisProcessList_readZoneName(spl->kd,sproc);
+   csproc->taskid           = _psinfo->pr_taskid;
+   csproc->projid           = _psinfo->pr_projid;
+   csproc->poolid           = _psinfo->pr_poolid;
+   csproc->contid           = _psinfo->pr_contract;
+   cproc->priority          = _lwpsinfo->pr_pri;
+   cproc->nice              = _lwpsinfo->pr_nice;
+   cproc->processor         = _lwpsinfo->pr_onpro;
+   cproc->state             = _lwpsinfo->pr_sname;
+   // This could potentially get bungled if the master LWP is not the first
+   // one enumerated.  Unaware of any workaround right now.
+   if ((cproc->state == 'O') && !onMasterLWP) proc->state = 'O';
+   // NOTE: This 'percentage' is a 16-bit BINARY FRACTIONS where 1.0 = 0x8000
+   // Source: https://docs.oracle.com/cd/E19253-01/816-5174/proc-4/index.html
+   // (accessed on 18 November 2017)
+   cproc->percent_mem       = ((uint16_t)_psinfo->pr_pctmem/(double)32768)*(double)100.0;
+   cproc->st_uid            = _psinfo->pr_euid;
+   cproc->user              = UsersTable_getRef(pl->usersTable, proc->st_uid);
+   cproc->pgrp              = _psinfo->pr_pgid;
+   cproc->nlwp              = _psinfo->pr_nlwp;
+   cproc->comm              = xStrdup(_psinfo->pr_fname);
+   cproc->commLen           = strnlen(_psinfo->pr_fname,PRFNSZ);
+   cproc->tty_nr            = _psinfo->pr_ttydev;
+   cproc->m_resident        = _psinfo->pr_rssize/PAGE_SIZE_KB;
+   cproc->m_size            = _psinfo->pr_size/PAGE_SIZE_KB;
+
+   if (!preExisting) {
+      csproc->realpid          = _psinfo->pr_pid;
+      csproc->lwpid            = lwpid_real;
+   }
+
+   // End common code pass 1
+
+   if (onMasterLWP) { // Are we on the representative LWP?
       proc->ppid            = (_psinfo->pr_ppid * 1024);
       proc->tgid            = (_psinfo->pr_ppid * 1024);
       sproc->realppid       = _psinfo->pr_ppid;
-      sproc->zoneid         = _psinfo->pr_zoneid;
-      sproc->zname          = SolarisProcessList_readZoneName(spl->kd,sproc);
-      // NOTE: These 'percentages' are 16-bit BINARY FRACTIONS where 1.0 = 0x8000
-      // Source: https://docs.oracle.com/cd/E19253-01/816-5174/proc-4/index.html
-      // (accessed on 18 November 2017)
+      // See note above (in common section) about this BINARY FRACTION
       proc->percent_cpu     = ((uint16_t)_psinfo->pr_pctcpu/(double)32768)*(double)100.0;
-      proc->percent_mem     = ((uint16_t)_psinfo->pr_pctmem/(double)32768)*(double)100.0;
-      proc->st_uid          = _psinfo->pr_euid;
-      proc->user            = UsersTable_getRef(pl->usersTable, proc->st_uid);
-      proc->pgrp            = _psinfo->pr_pgid;
-      proc->nlwp            = _psinfo->pr_nlwp;
-      proc->comm            = xStrdup(_psinfo->pr_fname);
-      proc->commLen         = strnlen(_psinfo->pr_fname,PRFNSZ);
-      proc->tty_nr          = _psinfo->pr_ttydev;
-      proc->m_resident      = _psinfo->pr_rssize/PAGE_SIZE_KB;
-      proc->m_size          = _psinfo->pr_size/PAGE_SIZE_KB;
-      proc->priority        = _psinfo->pr_lwp.pr_pri;
-      proc->nice            = _psinfo->pr_lwp.pr_nice;
-      proc->processor       = _psinfo->pr_lwp.pr_onpro;
-      proc->state           = _psinfo->pr_lwp.pr_sname;
       proc->time            = _psinfo->pr_time.tv_sec;
-      sproc->taskid         = _psinfo->pr_taskid;
-      sproc->projid         = _psinfo->pr_projid;
-      sproc->poolid         = _psinfo->pr_poolid;
-      sproc->contid         = _psinfo->pr_contract; 
-
-      // Tasks done only for NEW processes
-      if(!preExisting) {
+      if(!preExisting) { // Tasks done only for NEW processes
          sproc->is_lwp = false;
-         // Fake PID values used for sorting, since Solaris LWPs lack unique PIDs
-         proc->pid             = (_psinfo->pr_pid * 1024);
-         // Corresponding real values used for display
-         sproc->realpid        = _psinfo->pr_pid;
-         sproc->lwpid          = 1;
          proc->starttime_ctime = _psinfo->pr_start.tv_sec;
-         if ((sproc->realppid <= 0) && !(sproc->realpid <= 1)) {
-            sproc->kernel = true;
-         } else {
-            sproc->kernel = false;
-         }
-         (void) localtime_r((time_t*) &proc->starttime_ctime, &date);
-         strftime(proc->starttime_show, 7, ((proc->starttime_ctime > tv.tv_sec - 86400) ? "%R " : "%b%d "), &date);
-         ProcessList_add(pl, proc);
       }
 
+      // Update proc and thread counts based on settings
       if (sproc->kernel && !pl->settings->hideKernelThreads) {
          pl->kernelThreads += proc->nlwp;
          pl->totalTasks += proc->nlwp+1;
@@ -385,11 +339,39 @@ int SolarisProcessList_walkproc(psinfo_t *_psinfo, lwpsinfo_t *_lwpsinfo, void *
          }
       }
       proc->show = !(pl->settings->hideKernelThreads && sproc->kernel);
-      proc->updated = true;
-   } else {
-      // We are not in the rep. LWP, so jump to the LWP handling code
-      ProcessList_enumerateLWPs(proc, pl, _lwpsinfo, tv);
+   } else { // We are not in the master LWP, so jump to the LWP handling code
+      lwp->percent_cpu        = ((uint16_t)_lwpsinfo->pr_pctcpu/(double)32768)*(double)100.0;
+      lwp->time               = _lwpsinfo->pr_time.tv_sec;
+      if (!preExisting) { // Tasks done only for NEW LWPs
+         slwp->is_lwp         = true; 
+         lwp->basenameOffset  = -1;
+         lwp->ppid            = proc->pid;
+         lwp->tgid            = proc->pid;
+         slwp->realppid       = sproc->realpid;
+         lwp->starttime_ctime = _lwpsinfo->pr_start.tv_sec;
+      }
+
+      // Top-level process only gets this for the representative LWP
+      if (slwp->kernel  && !pl->settings->hideKernelThreads)   lwp->show = true;
+      if (!slwp->kernel && !pl->settings->hideUserlandThreads) lwp->show = true;
+   } // Top-level LWP or subordinate LWP
+
+   // Common code pass 2
+
+   if (!preExisting) {
+      if ((sproc->realppid <= 0) && !(sproc->realpid <= 1)) {
+         csproc->kernel = true;
+      } else {
+         csproc->kernel = false;
+      }
+      (void) localtime_r((time_t*) &cproc->starttime_ctime, &date);
+      strftime(cproc->starttime_show, 7, ((cproc->starttime_ctime > tv.tv_sec - 86400) ? "%R " : "%b%d "), &date);
+      ProcessList_add(pl, cproc);
    }
+   cproc->updated = true;
+
+   // End common code pass 2
+
    return 0;
 }
 
@@ -397,6 +379,6 @@ void ProcessList_goThroughEntries(ProcessList* this) {
    SolarisProcessList_scanCPUTime(this);
    SolarisProcessList_scanMemoryInfo(this);
    this->kernelThreads = 1;
-   proc_walk( &SolarisProcessList_walkproc, this, PR_WALK_LWP );
+   proc_walk(&SolarisProcessList_walkproc, this, PR_WALK_LWP);
 }
 

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -284,6 +284,7 @@ int SolarisProcessList_walkproc(psinfo_t *_psinfo, lwpsinfo_t *_lwpsinfo, void *
    gettimeofday(&tv, NULL);
 
    // Common code pass 1
+   cproc->show              = false;
    csproc->zoneid           = _psinfo->pr_zoneid;
    csproc->zname            = SolarisProcessList_readZoneName(spl->kd,sproc);
    csproc->taskid           = _psinfo->pr_taskid;

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -238,169 +238,129 @@ void ProcessList_delete(ProcessList* this) {
    free(this);
 }
 
-void ProcessList_enumerateLWPs(Process* proc, char* name, struct ps_prochandle *Pr, ProcessList* pl, struct timeval tv) {
+void ProcessList_enumerateLWPs(Process* proc, ProcessList* pl, lwpsinfo_t *_lwpsinfo, struct timeval tv) {
    Process *lwp;
    SolarisProcess *slwp;
    SolarisProcess *sproc = (SolarisProcess*) proc;
-   char lwpdir[MAX_NAME+1];
-   DIR* dir = NULL;
+   id_t lwpid_real; 
    pid_t lwpid;
    bool preExisting = false;   
-   const lwpsinfo_t *_lwpsinfo;
    struct tm date;
-   xSnprintf(lwpdir, MAX_NAME, "%s/%s/lwp", PROCDIR, name);
-   struct dirent* entry;
-   char* lwpname;
-   struct ps_lwphandle* LWP;
-   int perr;
 
-   dir = opendir(lwpdir);
-   if (!dir) return;
-   while ((entry = readdir(dir)) != NULL) {
-      lwpname = entry->d_name;
-      // With 10 bits to spare, we can only list up to 1023 unique LWPs per process
-      if (atoi(lwpname) > 1023) break;
-      lwpid   = proc->pid + atoi(lwpname);
-      lwp     = ProcessList_getProcess(pl, lwpid, &preExisting, (Process_New) SolarisProcess_new);
-      slwp    = (SolarisProcess*) lwp;
-      if ((LWP=Lgrab(Pr,atoi(lwpname),&perr)) == NULL) continue;
-      _lwpsinfo = Lpsinfo(LWP);
+   // With 10 bits to spare, we can only list up to 1023 unique LWPs per process
+   lwpid_real = _lwpsinfo->pr_lwpid;
+   if (lwpid_real > 1023) return;
+   lwpid   = proc->pid + lwpid_real;
+   lwp     = ProcessList_getProcess(pl, lwpid, &preExisting, (Process_New) SolarisProcess_new);
+   slwp    = (SolarisProcess*) lwp;
 
-      // Common items set for both new and refreshed LWPs
-      slwp->zoneid            = sproc->zoneid;
-      lwp->percent_cpu        = ((uint16_t)_lwpsinfo->pr_pctcpu/(double)32768)*(double)100.0;
-      lwp->pgrp               = proc->pgrp;
-      lwp->st_uid             = proc->st_uid;
-      lwp->user               = UsersTable_getRef(pl->usersTable, lwp->st_uid);
-      lwp->session            = proc->session;
-      lwp->comm               = xStrdup(proc->comm);
-      lwp->commLen            = strnlen(proc->comm,PRFNSZ);
-      slwp->zname             = sproc->zname;
-      lwp->tty_nr             = proc->tty_nr;
-      lwp->priority           = _lwpsinfo->pr_pri;
-      lwp->nice               = _lwpsinfo->pr_nice;
-      lwp->processor          = _lwpsinfo->pr_onpro;
-      lwp->state              = _lwpsinfo->pr_sname;
-      lwp->time               = _lwpsinfo->pr_time.tv_sec;
-      slwp->taskid            = sproc->taskid;
-      slwp->projid            = sproc->projid;
-      slwp->poolid            = sproc->poolid;
-      slwp->contid            = sproc->contid;
-      lwp->show               = false;
+   // Common items set for both new and refreshed LWPs
+   slwp->zoneid            = sproc->zoneid;
+   lwp->percent_cpu        = ((uint16_t)_lwpsinfo->pr_pctcpu/(double)32768)*(double)100.0;
+   lwp->pgrp               = proc->pgrp;
+   lwp->st_uid             = proc->st_uid;
+   lwp->user               = UsersTable_getRef(pl->usersTable, lwp->st_uid);
+   lwp->session            = proc->session;
+   lwp->comm               = xStrdup(proc->comm);
+   lwp->commLen            = strnlen(proc->comm,PRFNSZ);
+   slwp->zname             = sproc->zname;
+   lwp->tty_nr             = proc->tty_nr;
+   lwp->priority           = _lwpsinfo->pr_pri;
+   lwp->nice               = _lwpsinfo->pr_nice;
+   lwp->processor          = _lwpsinfo->pr_onpro;
+   lwp->state              = _lwpsinfo->pr_sname;
+   lwp->time               = _lwpsinfo->pr_time.tv_sec;
+   slwp->taskid            = sproc->taskid;
+   slwp->projid            = sproc->projid;
+   slwp->poolid            = sproc->poolid;
+   slwp->contid            = sproc->contid;
+   lwp->show               = false;
 
-      // Tasks done only for NEW LWPs  
-      if (!preExisting) {
-         slwp->is_lwp         = true; 
-         lwp->basenameOffset  = -1;
-         slwp->kernel         = sproc->kernel;
-         // Fake values used for sorting
-         // Only set once because threads don't generally
-         // move... between... processes.
-         lwp->pid             = lwpid;
-         lwp->ppid            = proc->pid;
-         lwp->tgid            = proc->pid;
-         // Corresponding real values used for display
-         slwp->realpid        = sproc->realpid;
-         slwp->realppid       = sproc->realpid;
-         slwp->lwpid          = atoi(lwpname);
-         // Not tracked per thread
-         lwp->percent_mem     = (double)0.0;
-         lwp->nlwp            = 0;
-         lwp->m_resident      = 0;
-         lwp->m_size          = 0;
-         lwp->starttime_ctime = _lwpsinfo->pr_start.tv_sec;
-         (void) localtime_r((time_t*) &lwp->starttime_ctime, &date);
-         strftime(lwp->starttime_show, 7, ((lwp->starttime_ctime > tv.tv_sec - 86400) ? "%R " : "%b%d "), &date);
-         ProcessList_add(pl, lwp);
-      }
-
-      Lfree(LWP);
-
-      // Top-level process only gets this for the representative LWP
-      if (lwp->state == 'O') proc->state = 'O';
-      if (slwp->kernel  && !pl->settings->hideKernelThreads)   lwp->show = true;
-      if (!slwp->kernel && !pl->settings->hideUserlandThreads) lwp->show = true;
-      lwp->updated = true;
-
+   // Tasks done only for NEW LWPs  
+   if (!preExisting) {
+      slwp->is_lwp         = true; 
+      lwp->basenameOffset  = -1;
+      slwp->kernel         = sproc->kernel;
+      // Fake values used for sorting
+      // Only set once because threads don't generally
+      // move... between... processes.
+      lwp->pid             = lwpid;
+      lwp->ppid            = proc->pid;
+      lwp->tgid            = proc->pid;
+      // Corresponding real values used for display
+      slwp->realpid        = sproc->realpid;
+      slwp->realppid       = sproc->realpid;
+      slwp->lwpid          = lwpid_real;
+      // Not tracked per thread
+      lwp->percent_mem     = (double)0.0;
+      lwp->nlwp            = 0;
+      lwp->m_resident      = 0;
+      lwp->m_size          = 0;
+      lwp->starttime_ctime = _lwpsinfo->pr_start.tv_sec;
+      (void) localtime_r((time_t*) &lwp->starttime_ctime, &date);
+      strftime(lwp->starttime_show, 7, ((lwp->starttime_ctime > tv.tv_sec - 86400) ? "%R " : "%b%d "), &date);
+      ProcessList_add(pl, lwp);
    }
 
-   closedir(dir);
+   // Top-level process only gets this for the representative LWP
+   if (lwp->state == 'O') proc->state = 'O';
+   if (slwp->kernel  && !pl->settings->hideKernelThreads)   lwp->show = true;
+   if (!slwp->kernel && !pl->settings->hideUserlandThreads) lwp->show = true;
+   lwp->updated = true;
 
+   return;
 }
 
-
-void ProcessList_goThroughEntries(ProcessList* this) {
-   SolarisProcessList* spl = (SolarisProcessList*) this;
-   DIR* dir = NULL;
-   struct dirent* entry = NULL;
-   char*  name = NULL;
-   int    pid;
-   bool   preExisting = false;
-   Process* proc = NULL;
-   SolarisProcess* sproc = NULL;
-   psinfo_t _psinfo;
+int SolarisProcessList_walkproc(psinfo_t *_psinfo, lwpsinfo_t *_lwpsinfo, void *listptr) {
+   ProcessList *pl = (ProcessList*) listptr;
+   SolarisProcessList *spl = (SolarisProcessList*) listptr;
+   bool preExisting = false;
+   Process *proc = ProcessList_getProcess(pl, _psinfo->pr_pid * 1024, &preExisting, (Process_New) SolarisProcess_new);
+   SolarisProcess *sproc = (SolarisProcess*) proc;
    struct timeval tv;
    struct tm date;
-   struct ps_prochandle *Pr;
-   int gret;
 
-   gettimeofday(&tv, NULL);
-
-   // If these fail, then the relevant metrics will simply display as zero
-   SolarisProcessList_scanCPUTime(this);
-   SolarisProcessList_scanMemoryInfo(this);
-
-   dir = opendir(PROCDIR); 
-   if (!dir) return; // Is proc mounted?
-   // We always count the scheduler
-   this->kernelThreads = 1;
-   while ((entry = readdir(dir)) != NULL) {
-      name = entry->d_name;
-      pid = atoi(name);
-      proc = ProcessList_getProcess(this, pid, &preExisting, (Process_New) SolarisProcess_new);
-      sproc = (SolarisProcess *) proc;
-      if (proc_arg_psinfo(name, PR_ARG_ANY, &_psinfo, &gret) == -1) continue;
-      Pr = proc_arg_grab(name, PR_ARG_ANY, PGRAB_RDONLY, &gret);
-
+   // Are we on the representative LWP?
+   if (_lwpsinfo->pr_lwpid == _psinfo->pr_lwp.pr_lwpid) { 
       // Common items set for both new and refreshed processes
-      proc->ppid            = (_psinfo.pr_ppid * 1024);
-      proc->tgid            = (_psinfo.pr_ppid * 1024);
-      sproc->realppid       = _psinfo.pr_ppid;
-      sproc->zoneid         = _psinfo.pr_zoneid;
+      proc->ppid            = (_psinfo->pr_ppid * 1024);
+      proc->tgid            = (_psinfo->pr_ppid * 1024);
+      sproc->realppid       = _psinfo->pr_ppid;
+      sproc->zoneid         = _psinfo->pr_zoneid;
       sproc->zname          = SolarisProcessList_readZoneName(spl->kd,sproc);
       // NOTE: These 'percentages' are 16-bit BINARY FRACTIONS where 1.0 = 0x8000
       // Source: https://docs.oracle.com/cd/E19253-01/816-5174/proc-4/index.html
       // (accessed on 18 November 2017)
-      proc->percent_cpu     = ((uint16_t)_psinfo.pr_pctcpu/(double)32768)*(double)100.0;
-      proc->percent_mem     = ((uint16_t)_psinfo.pr_pctmem/(double)32768)*(double)100.0;
-      proc->st_uid          = _psinfo.pr_euid;
-      proc->user            = UsersTable_getRef(this->usersTable, proc->st_uid);
-      proc->pgrp            = _psinfo.pr_pgid;
-      proc->nlwp            = _psinfo.pr_nlwp;
-      proc->comm            = xStrdup(_psinfo.pr_fname);
-      proc->commLen         = strnlen(_psinfo.pr_fname,PRFNSZ);
-      proc->tty_nr          = _psinfo.pr_ttydev;
-      proc->m_resident      = _psinfo.pr_rssize/PAGE_SIZE_KB;
-      proc->m_size          = _psinfo.pr_size/PAGE_SIZE_KB;
-      proc->priority        = _psinfo.pr_lwp.pr_pri;
-      proc->nice            = _psinfo.pr_lwp.pr_nice;
-      proc->processor       = _psinfo.pr_lwp.pr_onpro;
-      proc->state           = _psinfo.pr_lwp.pr_sname;
-      proc->time            = _psinfo.pr_time.tv_sec;
-      sproc->taskid         = _psinfo.pr_taskid;
-      sproc->projid         = _psinfo.pr_projid;
-      sproc->poolid         = _psinfo.pr_poolid;
-      sproc->contid         = _psinfo.pr_contract;
-         
+      proc->percent_cpu     = ((uint16_t)_psinfo->pr_pctcpu/(double)32768)*(double)100.0;
+      proc->percent_mem     = ((uint16_t)_psinfo->pr_pctmem/(double)32768)*(double)100.0;
+      proc->st_uid          = _psinfo->pr_euid;
+      proc->user            = UsersTable_getRef(pl->usersTable, proc->st_uid);
+      proc->pgrp            = _psinfo->pr_pgid;
+      proc->nlwp            = _psinfo->pr_nlwp;
+      proc->comm            = xStrdup(_psinfo->pr_fname);
+      proc->commLen         = strnlen(_psinfo->pr_fname,PRFNSZ);
+      proc->tty_nr          = _psinfo->pr_ttydev;
+      proc->m_resident      = _psinfo->pr_rssize/PAGE_SIZE_KB;
+      proc->m_size          = _psinfo->pr_size/PAGE_SIZE_KB;
+      proc->priority        = _psinfo->pr_lwp.pr_pri;
+      proc->nice            = _psinfo->pr_lwp.pr_nice;
+      proc->processor       = _psinfo->pr_lwp.pr_onpro;
+      proc->state           = _psinfo->pr_lwp.pr_sname;
+      proc->time            = _psinfo->pr_time.tv_sec;
+      sproc->taskid         = _psinfo->pr_taskid;
+      sproc->projid         = _psinfo->pr_projid;
+      sproc->poolid         = _psinfo->pr_poolid;
+      sproc->contid         = _psinfo->pr_contract; 
+
       // Tasks done only for NEW processes
       if(!preExisting) {
          sproc->is_lwp = false;
          // Fake PID values used for sorting, since Solaris LWPs lack unique PIDs
-         proc->pid             = (_psinfo.pr_pid * 1024);
+         proc->pid             = (_psinfo->pr_pid * 1024);
          // Corresponding real values used for display
-         sproc->realpid        = _psinfo.pr_pid;
-         sproc->lwpid          = 0;
-         proc->starttime_ctime = _psinfo.pr_start.tv_sec;
+         sproc->realpid        = _psinfo->pr_pid;
+         sproc->lwpid          = 1;
+         proc->starttime_ctime = _psinfo->pr_start.tv_sec;
          if ((sproc->realppid <= 0) && !(sproc->realpid <= 1)) {
             sproc->kernel = true;
          } else {
@@ -408,34 +368,35 @@ void ProcessList_goThroughEntries(ProcessList* this) {
          }
          (void) localtime_r((time_t*) &proc->starttime_ctime, &date);
          strftime(proc->starttime_show, 7, ((proc->starttime_ctime > tv.tv_sec - 86400) ? "%R " : "%b%d "), &date);
-         ProcessList_add(this, proc);
+         ProcessList_add(pl, proc);
       }
 
-      if ((proc->nlwp > 1) && (Pr != NULL)) {
-         ProcessList_enumerateLWPs(proc, name, Pr, this, tv);
-      }
-      if (Pr != NULL) Prelease(Pr, 0);
-      proc->show = !(this->settings->hideKernelThreads && sproc->kernel);
-
-      if (sproc->kernel && !this->settings->hideKernelThreads) {
-         this->kernelThreads += proc->nlwp;
-         this->totalTasks += proc->nlwp+1;
-         if (proc->state == 'O') this->runningTasks++;
+      if (sproc->kernel && !pl->settings->hideKernelThreads) {
+         pl->kernelThreads += proc->nlwp;
+         pl->totalTasks += proc->nlwp+1;
+         if (proc->state == 'O') pl->runningTasks++;
       } else if (!sproc->kernel) {
-         if (proc->state == 'O') this->runningTasks++;
-         if (this->settings->hideUserlandThreads) {
-            this->totalTasks++;
+         if (proc->state == 'O') pl->runningTasks++;
+         if (pl->settings->hideUserlandThreads) {
+            pl->totalTasks++;
          } else {
-            this->userlandThreads += proc->nlwp;
-            this->totalTasks += proc->nlwp+1;
+            pl->userlandThreads += proc->nlwp;
+            pl->totalTasks += proc->nlwp+1;
          }
       }
-
+      proc->show = !(pl->settings->hideKernelThreads && sproc->kernel);
       proc->updated = true;
+   } else {
+      // We are not in the rep. LWP, so jump to the LWP handling code
+      ProcessList_enumerateLWPs(proc, pl, _lwpsinfo, tv);
+   }
+   return 0;
+}
 
-   } // while ((entry = readdir(dir)) != NULL)
-
-   closedir(dir);
-
+void ProcessList_goThroughEntries(ProcessList* this) {
+   SolarisProcessList_scanCPUTime(this);
+   SolarisProcessList_scanMemoryInfo(this);
+   this->kernelThreads = 1;
+   proc_walk( &SolarisProcessList_walkproc, this, PR_WALK_LWP );
 }
 

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -413,6 +413,8 @@ void ProcessList_goThroughEntries(ProcessList* this) {
 
    dir = opendir(PROCDIR); 
    if (!dir) return; // Is proc mounted?
+   // We always count the scheduler
+   this->kernelThreads = 1;
    while ((entry = readdir(dir)) != NULL) {
       addRunning = 0;
       addTotal = 0;
@@ -518,7 +520,7 @@ void ProcessList_goThroughEntries(ProcessList* this) {
          ProcessList_enumerateLWPs(proc, name, this, tv);
       }
       proc->show = !(hideKernelThreads && sproc->kernel);
-      if (_pstatus.pr_flags & sproc->kernel) {
+      if (sproc->kernel) {
          if (hideKernelThreads) {
             addRunning = 0;
             addTotal   = 0;

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -222,7 +222,6 @@ static inline void SolarisProcessList_scanMemoryInfo(ProcessList* pl) {
       for (int i = 0; i < nswap; i++, swapdev++) {
          totalswap += swapdev->ste_pages;
          totalfree += swapdev->ste_free;
-         free(swapdev);
       }
    }
    free(spathbase);
@@ -248,76 +247,56 @@ void ProcessList_delete(ProcessList* pl) {
 int SolarisProcessList_walkproc(psinfo_t *_psinfo, lwpsinfo_t *_lwpsinfo, void *listptr) {
    struct timeval tv;
    struct tm date;
-   bool preExistingP = false;
-   bool preExistingL = false;
    bool preExisting;
-   Process *cproc;
-   SolarisProcess *csproc;
+   pid_t getpid;
 
    // Setup process list
    ProcessList *pl = (ProcessList*) listptr;
    SolarisProcessList *spl = (SolarisProcessList*) listptr;
 
-   // Setup Process entry
-   Process *proc           = ProcessList_getProcess(pl, _psinfo->pr_pid * 1024, &preExistingP, (Process_New) SolarisProcess_new);
-   SolarisProcess *sproc   = (SolarisProcess*) proc;
-
-   // Setup LWP entry
    id_t lwpid_real = _lwpsinfo->pr_lwpid;
    if (lwpid_real > 1023) return 0;
-   pid_t lwpid   = proc->pid + lwpid_real;
-   Process *lwp            = ProcessList_getProcess(pl, lwpid, &preExistingL, (Process_New) SolarisProcess_new);
-   SolarisProcess *slwp    = (SolarisProcess*) lwp;
-
+   pid_t lwpid   = (_psinfo->pr_pid * 1024) + lwpid_real;
    bool onMasterLWP = (_lwpsinfo->pr_lwpid == _psinfo->pr_lwp.pr_lwpid);
-
-   // Determine whether we're updating proc info or LWP info
-   // based on whether or not we're on the representative LWP
-   // for a given proc
    if (onMasterLWP) {
-      cproc = proc;
-      csproc = sproc;
-      preExisting = preExistingP;
+      getpid = _psinfo->pr_pid * 1024;
    } else {
-      cproc = lwp;
-      csproc = slwp;
-      preExisting = preExistingL;
-   }
+      getpid = lwpid;
+   } 
+   Process *proc             = ProcessList_getProcess(pl, getpid, &preExisting, (Process_New) SolarisProcess_new);
+   SolarisProcess *sproc     = (SolarisProcess*) proc;
 
    gettimeofday(&tv, NULL);
 
    // Common code pass 1
-   cproc->show              = false;
-   csproc->taskid           = _psinfo->pr_taskid;
-   csproc->projid           = _psinfo->pr_projid;
-   csproc->poolid           = _psinfo->pr_poolid;
-   csproc->contid           = _psinfo->pr_contract;
-   cproc->priority          = _lwpsinfo->pr_pri;
-   cproc->nice              = _lwpsinfo->pr_nice;
-   cproc->processor         = _lwpsinfo->pr_onpro;
-   cproc->state             = _lwpsinfo->pr_sname;
-   // This could potentially get bungled if the master LWP is not the first
-   // one enumerated.  Unaware of any workaround right now.
-   if ((cproc->state == 'O') && !onMasterLWP) proc->state = 'O';
+   proc->show               = false;
+   sproc->taskid            = _psinfo->pr_taskid;
+   sproc->projid            = _psinfo->pr_projid;
+   sproc->poolid            = _psinfo->pr_poolid;
+   sproc->contid            = _psinfo->pr_contract;
+   proc->priority           = _lwpsinfo->pr_pri;
+   proc->nice               = _lwpsinfo->pr_nice;
+   proc->processor          = _lwpsinfo->pr_onpro;
+   proc->state              = _lwpsinfo->pr_sname;
    // NOTE: This 'percentage' is a 16-bit BINARY FRACTIONS where 1.0 = 0x8000
    // Source: https://docs.oracle.com/cd/E19253-01/816-5174/proc-4/index.html
    // (accessed on 18 November 2017)
-   cproc->percent_mem       = ((uint16_t)_psinfo->pr_pctmem/(double)32768)*(double)100.0;
-   cproc->st_uid            = _psinfo->pr_euid;
-   cproc->pgrp              = _psinfo->pr_pgid;
-   cproc->nlwp              = _psinfo->pr_nlwp;
-   cproc->tty_nr            = _psinfo->pr_ttydev;
-   cproc->m_resident        = _psinfo->pr_rssize/PAGE_SIZE_KB;
-   cproc->m_size            = _psinfo->pr_size/PAGE_SIZE_KB;
+   proc->percent_mem        = ((uint16_t)_psinfo->pr_pctmem/(double)32768)*(double)100.0;
+   proc->st_uid             = _psinfo->pr_euid;
+   proc->pgrp               = _psinfo->pr_pgid;
+   proc->nlwp               = _psinfo->pr_nlwp;
+   proc->tty_nr             = _psinfo->pr_ttydev;
+   proc->m_resident         = _psinfo->pr_rssize/PAGE_SIZE_KB;
+   proc->m_size             = _psinfo->pr_size/PAGE_SIZE_KB;
 
    if (!preExisting) {
-      csproc->realpid       = _psinfo->pr_pid;
-      csproc->lwpid         = lwpid_real;
-      csproc->zoneid        = _psinfo->pr_zoneid;
-      csproc->zname         = SolarisProcessList_readZoneName(spl->kd,sproc); 
-      cproc->user           = UsersTable_getRef(pl->usersTable, proc->st_uid);
-      cproc->comm           = xStrdup(_psinfo->pr_fname);
-      cproc->commLen        = strnlen(_psinfo->pr_fname,PRFNSZ);
+      sproc->realpid        = _psinfo->pr_pid;
+      sproc->lwpid          = lwpid_real;
+      sproc->zoneid         = _psinfo->pr_zoneid;
+      sproc->zname          = SolarisProcessList_readZoneName(spl->kd,sproc); 
+      proc->user            = UsersTable_getRef(pl->usersTable, proc->st_uid);
+      proc->comm            = xStrdup(_psinfo->pr_fname);
+      proc->commLen         = strnlen(_psinfo->pr_fname,PRFNSZ);
    }
 
    // End common code pass 1
@@ -329,7 +308,7 @@ int SolarisProcessList_walkproc(psinfo_t *_psinfo, lwpsinfo_t *_lwpsinfo, void *
       // See note above (in common section) about this BINARY FRACTION
       proc->percent_cpu     = ((uint16_t)_psinfo->pr_pctcpu/(double)32768)*(double)100.0;
       proc->time            = _psinfo->pr_time.tv_sec;
-      if(!preExistingP) { // Tasks done only for NEW processes
+      if(!preExisting) { // Tasks done only for NEW processes
          sproc->is_lwp = false;
          proc->starttime_ctime = _psinfo->pr_start.tv_sec;
       }
@@ -350,35 +329,35 @@ int SolarisProcessList_walkproc(psinfo_t *_psinfo, lwpsinfo_t *_lwpsinfo, void *
       }
       proc->show = !(pl->settings->hideKernelThreads && sproc->kernel);
    } else { // We are not in the master LWP, so jump to the LWP handling code
-      lwp->percent_cpu        = ((uint16_t)_lwpsinfo->pr_pctcpu/(double)32768)*(double)100.0;
-      lwp->time               = _lwpsinfo->pr_time.tv_sec;
-      if (!preExistingL) { // Tasks done only for NEW LWPs
-         slwp->is_lwp         = true; 
-         lwp->basenameOffset  = -1;
-         lwp->ppid            = proc->pid;
-         lwp->tgid            = proc->pid;
-         slwp->realppid       = sproc->realpid;
-         lwp->starttime_ctime = _lwpsinfo->pr_start.tv_sec;
+      proc->percent_cpu        = ((uint16_t)_lwpsinfo->pr_pctcpu/(double)32768)*(double)100.0;
+      proc->time               = _lwpsinfo->pr_time.tv_sec;
+      if (!preExisting) { // Tasks done only for NEW LWPs
+         sproc->is_lwp         = true; 
+         proc->basenameOffset  = -1;
+         proc->ppid            = _psinfo->pr_pid * 1024;
+         proc->tgid            = _psinfo->pr_pid * 1024;
+         sproc->realppid       = _psinfo->pr_pid;
+         proc->starttime_ctime = _lwpsinfo->pr_start.tv_sec;
       }
 
       // Top-level process only gets this for the representative LWP
-      if (slwp->kernel  && !pl->settings->hideKernelThreads)   lwp->show = true;
-      if (!slwp->kernel && !pl->settings->hideUserlandThreads) lwp->show = true;
+      if (sproc->kernel  && !pl->settings->hideKernelThreads)   proc->show = true;
+      if (!sproc->kernel && !pl->settings->hideUserlandThreads) proc->show = true;
    } // Top-level LWP or subordinate LWP
 
    // Common code pass 2
 
    if (!preExisting) {
       if ((sproc->realppid <= 0) && !(sproc->realpid <= 1)) {
-         csproc->kernel = true;
+         sproc->kernel = true;
       } else {
-         csproc->kernel = false;
+         sproc->kernel = false;
       }
-      (void) localtime_r((time_t*) &cproc->starttime_ctime, &date);
-      strftime(cproc->starttime_show, 7, ((cproc->starttime_ctime > tv.tv_sec - 86400) ? "%R " : "%b%d "), &date);
-      ProcessList_add(pl, cproc);
+      (void) localtime_r((time_t*) &proc->starttime_ctime, &date);
+      strftime(proc->starttime_show, 7, ((proc->starttime_ctime > tv.tv_sec - 86400) ? "%R " : "%b%d "), &date);
+      ProcessList_add(pl, proc);
    }
-   cproc->updated = true;
+   proc->updated = true;
 
    // End common code pass 2
 

--- a/solaris/SolarisProcessList.c
+++ b/solaris/SolarisProcessList.c
@@ -362,6 +362,8 @@ void ProcessList_enumerateLWPs(Process* proc, char* name, ProcessList* pl, struc
          slwp->poolid         = sproc->poolid;
          slwp->contid         = sproc->contid;
       }
+      // Top-level process only gets this for the representative LWP
+      if (lwp->state == 'O') proc->state = 'O';
       if (slwp->kernel) {
          if(!hideKernelThreads) {
             lwp->show = true;

--- a/solaris/SolarisProcessList.h
+++ b/solaris/SolarisProcessList.h
@@ -50,6 +50,12 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, ui
 
 void ProcessList_delete(ProcessList* this);
 
+/* NOTE: the following is a callback function of type proc_walk_f
+ *       and MUST conform to the appropriate definition in order
+ *       to work.  See libproc(3LIB) on a Solaris or Illumos
+ *       system for more info.
+ */ 
+
 int SolarisProcessList_walkproc(psinfo_t *_psinfo, lwpsinfo_t *_lwpsinfo, void *listptr);
 
 void ProcessList_goThroughEntries(ProcessList* this);

--- a/solaris/SolarisProcessList.h
+++ b/solaris/SolarisProcessList.h
@@ -50,7 +50,9 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, ui
 
 void ProcessList_delete(ProcessList* this);
 
-void ProcessList_enumerateLWPs(Process* proc, char* name, struct ps_prochandle *Pr, ProcessList* pl, struct timeval tv);
+void ProcessList_enumerateLWPs(Process* proc, ProcessList* pl, lwpsinfo_t *_lwpsinfo, struct timeval tv);
+
+int SolarisProcessList_walkproc(psinfo_t *_psinfo, lwpsinfo_t *_lwpsinfo, void *listptr);
 
 void ProcessList_goThroughEntries(ProcessList* this);
 

--- a/solaris/SolarisProcessList.h
+++ b/solaris/SolarisProcessList.h
@@ -50,8 +50,6 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, ui
 
 void ProcessList_delete(ProcessList* this);
 
-void ProcessList_enumerateLWPs(Process* proc, ProcessList* pl, lwpsinfo_t *_lwpsinfo, struct timeval tv);
-
 int SolarisProcessList_walkproc(psinfo_t *_psinfo, lwpsinfo_t *_lwpsinfo, void *listptr);
 
 void ProcessList_goThroughEntries(ProcessList* this);

--- a/solaris/SolarisProcessList.h
+++ b/solaris/SolarisProcessList.h
@@ -48,7 +48,7 @@ char* SolarisProcessList_readZoneName(kstat_ctl_t* kd, SolarisProcess* sproc);
 
 ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, uid_t userId);
 
-void ProcessList_delete(ProcessList* this);
+void ProcessList_delete(ProcessList* pl);
 
 /* NOTE: the following is a callback function of type proc_walk_f
  *       and MUST conform to the appropriate definition in order

--- a/solaris/SolarisProcessList.h
+++ b/solaris/SolarisProcessList.h
@@ -15,7 +15,6 @@ in the source distribution for its full text.
 
 #include <kstat.h>
 #include <sys/param.h>
-#include <zone.h>
 #include <sys/uio.h>
 #include <sys/resource.h>
 #include <sys/sysconf.h>
@@ -51,7 +50,7 @@ ProcessList* ProcessList_new(UsersTable* usersTable, Hashtable* pidWhiteList, ui
 
 void ProcessList_delete(ProcessList* this);
 
-void ProcessList_enumerateLWPs(Process* proc, char* name, ProcessList* pl, struct timeval tv);
+void ProcessList_enumerateLWPs(Process* proc, char* name, struct ps_prochandle *Pr, ProcessList* pl, struct timeval tv);
 
 void ProcessList_goThroughEntries(ProcessList* this);
 


### PR DESCRIPTION
Solaris port change summary:
- Removed all direct interaction with procfs files and dirs in favor of libproc usage (MAJOR CHANGE)
- Implemented process environment display
- Consolidated separate process vs LWP info-gathering loops into one (MAJOR CHANGE)
- Assorted cosmetic improvements

NOTE: this PR modifies configure.ac to add a new library dependency (libproc) if the Solaris platform is detected, alongside the existing libkstat and libmalloc dependencies.