### PR TITLE
Disable 'make dist' when pkg.m4 is unused in configure

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -210,6 +210,13 @@ coverage:
 cppcheck:
 	cppcheck -q -v . --enable=all -DHAVE_CGROUP -DHAVE_OPENVZ -DHAVE_TASKSTATS
 
+dist-hook: $(top_distdir)/configure
+	@if grep 'pkg_m4_absent' '$(top_distdir)/configure'; then \
+	   echo 'configure is generated without pkg.m4. Please supply pkg.m4 and run ./autogen.sh to rebuild the configure script.'>&2; \
+	   (exit 1); \
+	else :; \
+	fi
+
 .PHONY: lcov
 
 lcov:

--- a/configure.ac
+++ b/configure.ac
@@ -292,7 +292,9 @@ then
       LIBS="$LIBS $LIBNL3_LIBS $LIBNL3GENL_LIBS"
       AC_DEFINE(HAVE_DELAYACCT, 1, [Define if delay accounting support should be enabled.])
    ], [
-     AC_MSG_ERROR([htop on Linux requires pkg-config for checking delayacct requirements. Please install pkg-config and run ./autogen.sh to rebuild the configure script.])
+      pkg_m4_absent=1
+      m4_warning([configure is generated without pkg.m4. 'make dist' target will be disabled.])
+      AC_MSG_ERROR([htop on Linux requires pkg-config for checking delayacct requirements. Please install pkg-config and run ./autogen.sh to rebuild the configure script.])
    ])
 fi
 


### PR DESCRIPTION
Follow-up of #775.
This would prevent a careless future package maintainer (forks or distros) from creating a release tarball with a defective configure script. :)

Also, add a warning in the autogen.sh phase if pkg.m4 is unused.