### PR TITLE
Solaris: Make last change to Platform.h persistent

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -247,7 +247,7 @@ if test "$my_htop_platform" = "solaris"; then
    AC_CHECK_LIB([malloc], [free], [], [missing_libraries="$missing_libraries libmalloc"])
    AC_CHECK_HEADERS([err.h],[:],[
       missing_headers="$missing_headers err.h"
-      AC_MSG_ERROR([You appear to be on Solaris 10, or very early Solaris Express, which is currently unsupported.])
+      AC_MSG_ERROR([You appear to be on Solaris 10, or very early Solaris Express, which are currently unsupported.])
    ])
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -245,6 +245,10 @@ if test "$my_htop_platform" = "solaris"; then
    AC_CHECK_LIB([kstat], [kstat_open], [], [missing_libraries="$missing_libraries libkstat"])
    AC_CHECK_LIB([proc], [Pgrab_error], [], [missing_libraries="$missing_libraries libproc"])
    AC_CHECK_LIB([malloc], [free], [], [missing_libraries="$missing_libraries libmalloc"])
+   AC_CHECK_HEADERS([err.h],[:],[
+      missing_headers="$missing_headers err.h"
+      AC_MSG_ERROR([You appear to be on Solaris 10, or very early Solaris Express, which is currently unsupported.])
+   ])
 fi
 
 AC_ARG_ENABLE(linux_affinity, [AS_HELP_STRING([--enable-linux-affinity], [enable Linux sched_setaffinity and sched_getaffinity for affinity support, disables hwloc])], ,enable_linux_affinity="yes")

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -35,6 +35,7 @@ in the source distribution for its full text.
 #include "Action.h"
 #include "BatteryMeter.h"
 #include "SignalsPanel.h"
+#include "SolarisProcess.h"
 #include <signal.h>
 #include <sys/mkdev.h>
 #include <sys/proc.h>


### PR DESCRIPTION
Fix a "whoops" - last change to solaris/Platform.h gets clobbered when that file is regenerated.  This makes the change persistent.