### PR TITLE
Fix #define to match header when regenerating with MakeHeader.py

### DIFF
--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -143,7 +143,7 @@ typedef struct LinuxProcess_ {
 } LinuxProcess;
 
 #ifndef Process_isKernelThread
-#define Process_isKernelThread(_process) ((LinuxProcess*)(_process)->isKernelThread)
+#define Process_isKernelThread(_process) (((LinuxProcess*)(_process))->isKernelThread)
 #endif
 
 #ifndef Process_isUserlandThread


### PR DESCRIPTION
from Debian https://sources.debian.org/src/htop/2.2.0-1/debian/patches/fix-linux-process.patch/

The LinuxProcess.h and LinuxProcess.c don't match which means htop 2.2.0 only compiles until you regen the header files. This fixes the inconsistency from 47cf1532b0c9fbc70bada5022a7db07d3cc4811a.
/DLange
