### PR TITLE
Fix parsing -s on the command line after db05ba610

### DIFF
--- a/htop.c
+++ b/htop.c
@@ -93,7 +93,7 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
 
    int opt, opti=0;
    /* Parse arguments */
-   while ((opt = getopt_long(argc, argv, "hvCst::d:u:p:i", long_opts, &opti))) {
+   while ((opt = getopt_long(argc, argv, "hvCts:d:u:p:i", long_opts, &opti))) {
       if (opt == EOF) break;
       switch (opt) {
          case 'h':


### PR DESCRIPTION
The named commit added an option parameter to -t, but seems to have
mistakenly added the `:` in the wrong place, thus breaking the parsing
of `-s` (segfaults with optarg=NULL).