### PR TITLE
Fix process name updates for shorter strings

### DIFF
--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -709,7 +709,7 @@ static bool LinuxProcessList_readCmdlineFile(Process* process, const char* dirna
    }
    command[lastChar + 1] = '\0';
    process->basenameOffset = tokenEnd;
-   setCommand(process, command, lastChar);
+   setCommand(process, command, lastChar + 1);
 
    return true;
 }


### PR DESCRIPTION
When a process name changes from a long string to a short string,
truncate instead of just overwriting the beginning.

# Reproduction steps

1. Run htop with a reasonable update frequency and `Update process names on every refresh` turned on.
2. Run a command which switches to a shorter name, e.g. `sh -c "sleep 5; exec vim"`
3. Watch this process in htop - its name will change from `sh -c sleep 5; exec vim` to `vim-c sleep 5; exec vim`

# Cause

A "last char" index was being treated as a string length, resulting in an off-by-one error.
