### PR TITLE
Fix CPU meters

### DIFF
--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -220,7 +220,7 @@ double Platform_setCPUValues(Meter* this, int cpu) {
    percentages(CPUSTATES, diff_v, new_v,
          (int64_t *)old_v[cpu-1], scratch_v);
 
-   for (i = 0; i < CPUSTATES; i++) {
+   for (i = 0; i < CPUSTATES - 1; i++) {
       old_v[cpu-1][i] = new_v[i];
       v[i] = diff_v[i] / 10.;
    }

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -46,7 +46,7 @@ extern ProcessFieldData Process_fields[];
 
 #define MAXCPU 256
 // XXX: probably should be a struct member
-static int64_t old_v[MAXCPU][5];
+static int64_t old_v[MAXCPU][CPUSTATES];
 
 /*
  * Copyright (c) 1984, 1989, William LeFebvre, Rice University
@@ -225,7 +225,7 @@ double Platform_setCPUValues(Meter* this, int cpu) {
       v[i] = diff_v[i] / 10.;
    }
 
-   Meter_setItems(this, 4);
+   Meter_setItems(this, CP_IDLE);
 
    perc = v[0] + v[1] + v[2] + v[3];
 

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -220,7 +220,7 @@ double Platform_setCPUValues(Meter* this, int cpu) {
    percentages(CPUSTATES, diff_v, new_v,
          (int64_t *)old_v[cpu-1], scratch_v);
 
-   for (i = 0; i < CPUSTATES - 1; i++) {
+   for (i = 0; i < CPUSTATES; i++) {
       old_v[cpu-1][i] = new_v[i];
       v[i] = diff_v[i] / 10.;
    }


### PR DESCRIPTION
Introduction of CP_SPIN sched state broke hard-coded state indexes
resulting in the meters incorrectly reporting bogus intr data instead of
CPU usage. Change hardcoded values to sched.h macros.