### PR TITLE
Update OpenBSD maximum PID

### DIFF
--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -197,7 +197,7 @@ void Platform_getLoadAverage(double* one, double* five, double* fifteen) {
 
 int Platform_getMaxPid() {
    // this is hard-coded in sys/sys/proc.h - no sysctl exists
-   return 32766;
+   return 99999;
 }
 
 double Platform_setCPUValues(Meter* this, int cpu) {


### PR DESCRIPTION
From the commit message:

> The htop source code correctly states that the maximum PID number in the OpenBSD kernel is fixed in `sys/sys/proc.h`, however this was updated in revision 1.215 (two years ago!) from 32766 to 99999.