### PR TITLE
Add support for displaying threads under OpenBSD

### DIFF
--- a/ProcessList.c
+++ b/ProcessList.c
@@ -225,7 +225,7 @@ void ProcessList_sort(ProcessList* this) {
                process = (Process*)(Vector_take(this->processes, i));
                process->indent = 0;
                Vector_add(this->processes2, process);
-               ProcessList_buildTree(this, process->pid, 0, 0, direction, false);
+               ProcessList_buildTree(this, process->pid, 0, 0, direction, process->showChildren);
                break;
             }
             pid_t ppid = Process_getParentPid(process);

--- a/openbsd/OpenBSDProcess.c
+++ b/openbsd/OpenBSDProcess.c
@@ -230,5 +230,5 @@ long OpenBSDProcess_compare(const void* v1, const void* v2) {
 }
 
 bool Process_isThread(Process* this) {
-   return (Process_isKernelThread(this));
+   return (Process_isKernelThread(this) || Process_isUserlandThread(this));
 }

--- a/openbsd/OpenBSDProcessList.c
+++ b/openbsd/OpenBSDProcessList.c
@@ -228,24 +228,23 @@ void ProcessList_goThroughEntries(ProcessList* this) {
 
    OpenBSDProcessList_scanMemoryInfo(this);
 
-   // use KERN_PROC_KTHREAD to also include kernel threads
-   struct kinfo_proc* kprocs = kvm_getprocs(opl->kd, KERN_PROC_ALL, 0, sizeof(struct kinfo_proc), &count);
-   //struct kinfo_proc* kprocs = getprocs(KERN_PROC_ALL, 0, &count);
+   struct kinfo_proc* kprocs = kvm_getprocs(opl->kd, KERN_PROC_KTHREAD | KERN_PROC_SHOW_THREADS, 0, sizeof(struct kinfo_proc), &count);
 
    for (i = 0; i < count; i++) {
       kproc = &kprocs[i];
 
       preExisting = false;
-      proc = ProcessList_getProcess(this, kproc->p_pid, &preExisting, (Process_New) OpenBSDProcess_new);
+      proc = ProcessList_getProcess(this, kproc->p_tid == -1 ? kproc->p_pid : kproc->p_tid, &preExisting, (Process_New) OpenBSDProcess_new);
       fp = (OpenBSDProcess*) proc;
 
       proc->show = ! ((hideKernelThreads && Process_isKernelThread(proc))
                   || (hideUserlandThreads && Process_isUserlandThread(proc)));
 
       if (!preExisting) {
-         proc->ppid = kproc->p_ppid;
+         proc->ppid = kproc->p_tid == -1 ? kproc->p_ppid : kproc->p_pid;
          proc->tpgid = kproc->p_tpgid;
          proc->tgid = kproc->p_pid;
+         proc->pid = kproc->p_tid == -1 ? kproc->p_pid : kproc->p_tid;
          proc->session = kproc->p_sid;
          proc->tty_nr = kproc->p_tdev;
          proc->pgrp = kproc->p__pgid;

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -197,7 +197,7 @@ void Platform_getLoadAverage(double* one, double* five, double* fifteen) {
 
 int Platform_getMaxPid() {
    // this is hard-coded in sys/sys/proc.h - no sysctl exists
-   return 32766;
+   return 0x7ffff;
 }
 
 double Platform_setCPUValues(Meter* this, int cpu) {


### PR DESCRIPTION
This patch adds support for displaying individual threads in a process on OpenBSD. **The following points should be noted:**

 - A call to `ProcessList_buildTree()` has been changed so that the process's `showChildren` flag always controls whether child processes are shown in tree view. This is necessary because on OpenBSD process ID 1 (`init(8)`) is a child process of the kernel thread with PID 0 (unlike other systems, where PID 0 is not visible from userspace and the first kernel thread has PID 2). By default, if a process is marked hidden then all of it's children will be hidden, which causes no processes to be displayed when hiding kernel threads is enabled. I do not know if this change will cause regressions elsewhere.

- The flags passed to `kvm_getprocs(3)` have been changed to also return all threads visible from userspace, which includes kernel threads and threads within processes (similar to the current Linux code). The semantics of some of the fields in the `Process` object are Linux specific -- `pid` (process ID) and `tgid` (thread group ID) -- and so they are used slightly differently in this patch. Note the following:

   1. On OpenBSD, processes are composed of multiple threads. Each process shares the same PID, but different threads have different thread ID's.
   2. Both indiviudal threads and complete processes are returned by `kvm_getprocs(3)`. The thread ID of the `struct kinfo_proc` returned for the overall process has a thread ID of -1. All other thread ID's are randomly assigned, as with PID's.
   3. As all processes have at least one thread, this means that information for every single-threaded process is returned twice: once for the process and once for the singleton thread.
   4. The value of a PID is currently capped at 99999 (see #818), however thread ID's are always *greater* than this value, but capped at 0x7ffff (524297 decimal).

   The patch therefore assigns the process ID and thread group ID as follows: if the `struct` returned represents the overall process (thread ID is set to -1), then the htop thread group ID is set to the process's kernel PID, and the htop PID and htop parent PID are set as normal. If the thread ID is *not* -1, then the htop thread group ID is set to the kernel PID, the htop PID is set to the kernel thread ID and the parent PID is set to the kernel PID. (This emulates the behaviour of examining threads under Linux in htop). **Note that this means that with userland threads turned on every process in the process tree will show at least one thread, unlike Linux.**

 - The maximum PID on OpenBSD is changed again in this patch (duplicating #818) as PID's and thread ID's share the same numeric interval, but occupy different ranges.