### PR TITLE
*bsd: mark unreachable code with comment

### DIFF
--- a/dragonflybsd/DragonFlyBSDProcess.c
+++ b/dragonflybsd/DragonFlyBSDProcess.c
@@ -122,11 +122,12 @@ void DragonFlyBSDProcess_writeField(Process* this, RichString* str, ProcessField
    case JID: xSnprintf(buffer, n, Process_pidFormat, fp->jid); break;
    case JAIL:{
       xSnprintf(buffer, n, "%-11s ", fp->jname); break;
-      if (buffer[11] != '\0') {
+      /* !!! unreachable
+         if (buffer[11] != '\0') {
          buffer[11] = ' ';
          buffer[12] = '\0';
       }
-      break;
+      break;*/
    }
    default:
       Process_writeField(this, str, field);

--- a/htop.c
+++ b/htop.c
@@ -87,13 +87,12 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
       {"no-colour",no_argument,         0, 'C'},
       {"tree",     no_argument,         0, 't'},
       {"pid",      required_argument,   0, 'p'},
-      {"io",       no_argument,         0, 'i'},
       {0,0,0,0}
    };
 
    int opt, opti=0;
    /* Parse arguments */
-   while ((opt = getopt_long(argc, argv, "hvCs:td:u:p:i", long_opts, &opti))) {
+   while ((opt = getopt_long(argc, argv, "hvCs:td:u:p:", long_opts, &opti))) {
       if (opt == EOF) break;
       switch (opt) {
          case 'h':

--- a/openbsd/OpenBSDProcess.c
+++ b/openbsd/OpenBSDProcess.c
@@ -209,7 +209,7 @@ void OpenBSDProcess_writeField(Process* this, RichString* str, ProcessField fiel
       Process_writeField(this, str, field);
       return;
    }
-   RichString_append(str, attr, buffer);
+   // RichString_append(str, attr, buffer); // <!-- unreachable
 }
 
 long OpenBSDProcess_compare(const void* v1, const void* v2) {


### PR DESCRIPTION
This may be undesired and the code should be revisited by the maintainers of these two occurances.