### PR TITLE
Restore meter name after used in Header_addMeterByName()

### DIFF
--- a/Header.c
+++ b/Header.c
@@ -120,6 +120,8 @@ MeterModeId Header_addMeterByName(Header* this, char* name, int column) {
          break;
       }
    }
+   if (paren)
+      *paren = '(';
    return mode;
 }
 


### PR DESCRIPTION
The left parenthesis is set to '\0' and not restored in [`Header_addMeterByName()`](https://github.com/hishamhm/htop/blob/b7b4200f854f667a917b7da8f92b3e0426131bd7/Header.c#L112), which is called during loading htoprc settings. If some changes not related to the top columns (like toggling tree view) triggers writing htoprc, CPU will be written to htoprc instead of CPU(n).

This PR will fix #637, fix #852