### PR TITLE
Don't follow process when selecting non-process-specific options

### DIFF
--- a/Action.h
+++ b/Action.h
@@ -39,7 +39,7 @@ typedef struct State_ {
 } State;
 
 
-Object* Action_pickFromVector(State* st, Panel* list, int x);
+Object* Action_pickFromVector(State* st, Panel* list, int x, bool followProcess);
 
 // ----------------------------------------
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -93,7 +93,7 @@ static Htop_Reaction Platform_actionSetIOPriority(State* st) {
    if (!p) return HTOP_OK;
    IOPriority ioprio = p->ioPriority;
    Panel* ioprioPanel = IOPriorityPanel_new(ioprio);
-   void* set = Action_pickFromVector(st, ioprioPanel, 21);
+   void* set = Action_pickFromVector(st, ioprioPanel, 21, true);
    if (set) {
       IOPriority ioprio = IOPriorityPanel_getIOPriority(ioprioPanel);
       bool ok = MainPanel_foreachProcess((MainPanel*)panel, (MainPanel_ForeachProcessFn) LinuxProcess_setIOPriority, (Arg){ .i = ioprio }, NULL);


### PR DESCRIPTION
Currently `Action_pickFromVector()` will follow the selected process and check if it remains the same after an option is selected. While this is useful when performing process-specific actions (so you don't kill another process by accident), this behavior should be disabled when selecting non-process-specific options, such as selecting sort order or selecting user filter.

This PR added a new parameter, `bool followProcess` to `Action_pickFromVector()`, and only follows the process when it is set to `true`.

This PR will fix #856