### PR TITLE
Fix warning about "major" macro with glibc 2.27

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,15 +64,22 @@ AC_CHECK_HEADERS([stdlib.h string.h strings.h sys/param.h sys/time.h unistd.h],[
 ])
 AC_CHECK_HEADERS([execinfo.h],[:],[:])
 
-AC_HEADER_MAJOR
 dnl glibc 2.25 deprecates 'major' and 'minor' in <sys/types.h> and requires to
-dnl include <sys/sysmacros.h>. However the logic in AC_HEADER_MAJOR has not yet
-dnl been updated in Autoconf 2.69, so use a workaround:
-m4_version_prereq([2.70], [],
-[if test "x$ac_cv_header_sys_mkdev_h" = xno; then
-   AC_CHECK_HEADER(sys/sysmacros.h, [AC_DEFINE(MAJOR_IN_SYSMACROS, 1,
-      [Define to 1 if `major', `minor', and `makedev' are declared in <sys/sysmacros.h>.])])
-fi])
+dnl include <sys/sysmacros.h>. Autoconf<=2.69 doesn't care about it.
+AC_DEFUN([AC_HEADER_MAJOR_270], dnl from autoconf lib/autoconf/headers.m4 @e17a30e987d
+[AC_CHECK_HEADERS_ONCE([sys/types.h])
+AC_CHECK_HEADER(sys/mkdev.h,
+    [AC_DEFINE(MAJOR_IN_MKDEV, 1,
+         [Define to 1 if `major', `minor', and `makedev' are
+          declared in <mkdev.h>.])])
+if test $ac_cv_header_sys_mkdev_h = no; then
+  AC_CHECK_HEADER(sys/sysmacros.h,
+      [AC_DEFINE(MAJOR_IN_SYSMACROS, 1,
+           [Define to 1 if `major', `minor', and `makedev'
+            are declared in <sysmacros.h>.])])
+fi
+])# AC_HEADER_MAJOR_270
+m4_version_prereq([2.70], [AC_HEADER_MAJOR], [AC_HEADER_MAJOR_270])
 
 # Checks for typedefs, structures, and compiler characteristics.
 # ----------------------------------------------------------------------


### PR DESCRIPTION
Fixes:

    gcc -DHAVE_CONFIG_H -I. -I..  -DNDEBUG  -pedantic -Wall -Wextra -std=c99 -D_XOPEN_SOURCE_EXTENDED -DSYSCONFDIR=\"/home/wsh/usr/opt/htop/etc\" -I"../linux" -rdynamic -D_GNU_SOURCE -D_DEFAULT_SOURCE -I/usr/include/ncursesw -ggdb3 -O0 -MT Process.o -MD -MP -MF $depbase.Tpo -c -o Process.o ../Process.c &&\
    mv -f $depbase.Tpo $depbase.Po
    ../Process.c: In function ‘Process_writeField’:
    ../Process.c:473:13: warning: In the GNU C Library, "major" is defined
     by <sys/sysmacros.h>. For historical compatibility, it is
     currently defined by <sys/types.h> as well, but we plan to
     remove this soon. To use "major", include <sys/sysmacros.h>
     directly. If you did not intend to use a system-defined macro
     "major", you should undefine it after including <sys/types.h>.
        case TTY_NR: xSnprintf(buffer, n, "%3u:%3u ", major(this->tty_nr), minor(this->tty_nr)); break;
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

In the previous configure.ac, MAJOR_IN_SYSMACROS was not defined even if
"major" is defined in <sys/sysmacros.h>.

Code snnipet is copied from:
https://git.savannah.gnu.org/gitweb/?p=autoconf.git;a=blob;f=lib/autoconf/headers.m4;hb=e17a30e987d7ee695fb4294a82d987ec3dc9b974