### PR TITLE
Fix CPU usage on OpenBSD

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -228,7 +228,7 @@ void Process_humanNumber(RichString* str, unsigned long number, bool coloring) {
    if(number >= (10 * ONE_DECIMAL_M)) {
       #ifdef __LP64__
       if(number >= (100 * ONE_DECIMAL_G)) {
-         len = snprintf(buffer, 10, "%4ldT ", number / ONE_G);
+         len = snprintf(buffer, 10, "%4luT ", number / ONE_G);
          RichString_appendn(str, largeNumberColor, buffer, len);
          return;
       } else if (number >= (1000 * ONE_DECIMAL_M)) {
@@ -238,7 +238,7 @@ void Process_humanNumber(RichString* str, unsigned long number, bool coloring) {
       }
       #endif
       if(number >= (100 * ONE_DECIMAL_M)) {
-         len = snprintf(buffer, 10, "%4ldG ", number / ONE_M);
+         len = snprintf(buffer, 10, "%4luG ", number / ONE_M);
          RichString_appendn(str, largeNumberColor, buffer, len);
          return;
       }
@@ -246,11 +246,11 @@ void Process_humanNumber(RichString* str, unsigned long number, bool coloring) {
       RichString_appendn(str, largeNumberColor, buffer, len);
       return;
    } else if (number >= 100000) {
-      len = snprintf(buffer, 10, "%4ldM ", number / ONE_K);
+      len = snprintf(buffer, 10, "%4luM ", number / ONE_K);
       RichString_appendn(str, processMegabytesColor, buffer, len);
       return;
    } else if (number >= 1000) {
-      len = snprintf(buffer, 10, "%2ld", number/1000);
+      len = snprintf(buffer, 10, "%2lu", number/1000);
       RichString_appendn(str, processMegabytesColor, buffer, len);
       number %= 1000;
       len = snprintf(buffer, 10, "%03lu ", number);
@@ -278,7 +278,7 @@ void Process_colorNumber(RichString* str, unsigned long long number, bool colori
       int len = snprintf(buffer, 13, "    no perm ");
       RichString_appendn(str, CRT_colors[PROCESS_SHADOW], buffer, len);
    } else if (number > 10000000000) {
-      xSnprintf(buffer, 13, "%11lld ", number / 1000);
+      xSnprintf(buffer, 13, "%11llu ", number / 1000);
       RichString_appendn(str, largeNumberColor, buffer, 5);
       RichString_appendn(str, processMegabytesColor, buffer+5, 3);
       RichString_appendn(str, processColor, buffer+8, 4);
@@ -380,9 +380,9 @@ void Process_writeField(Process* this, RichString* str, ProcessField field) {
    switch (field) {
    case PERCENT_CPU: {
       if (this->percent_cpu > 999.9) {
-         xSnprintf(buffer, n, "%4d ", (unsigned int)this->percent_cpu); 
+         xSnprintf(buffer, n, "%4u ", (unsigned int)this->percent_cpu); 
       } else if (this->percent_cpu > 99.9) {
-         xSnprintf(buffer, n, "%3d. ", (unsigned int)this->percent_cpu); 
+         xSnprintf(buffer, n, "%3u. ", (unsigned int)this->percent_cpu); 
       } else {
          xSnprintf(buffer, n, "%4.1f ", this->percent_cpu);
       }

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -145,14 +145,12 @@ static void checkRecalculation(ScreenManager* this, double* oldTime, int* sortTi
 }
 
 static void ScreenManager_drawPanels(ScreenManager* this, int focus) {
-   int nPanels = this->panelCount;
+   const int nPanels = this->panelCount;
    for (int i = 0; i < nPanels; i++) {
       Panel* panel = (Panel*) Vector_get(this->panels, i);
       Panel_draw(panel, i == focus);
-      if (i < nPanels) {
-         if (this->orientation == HORIZONTAL) {
-            mvvline(panel->y, panel->x+panel->w, ' ', panel->h+1);
-         }
+      if (this->orientation == HORIZONTAL) {
+         mvvline(panel->y, panel->x+panel->w, ' ', panel->h+1);
       }
    }
 }

--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -84,9 +84,8 @@ void ProcessList_freeCPULoadInfo(processor_cpu_load_info_t *p) {
        if(0 != munmap(*p, vm_page_size)) {
            CRT_fatalError("Unable to free old CPU load information\n");
        }
+       *p = NULL;
    }
-
-   *p = NULL;
 }
 
 unsigned ProcessList_allocateCPULoadInfo(processor_cpu_load_info_t *p) {

--- a/htop.c
+++ b/htop.c
@@ -87,13 +87,12 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
       {"no-colour",no_argument,         0, 'C'},
       {"tree",     no_argument,         0, 't'},
       {"pid",      required_argument,   0, 'p'},
-      {"io",       no_argument,         0, 'i'},
       {0,0,0,0}
    };
 
    int opt, opti=0;
    /* Parse arguments */
-   while ((opt = getopt_long(argc, argv, "hvCs:td:u:p:i", long_opts, &opti))) {
+   while ((opt = getopt_long(argc, argv, "hvCs:td:u:p:", long_opts, &opti))) {
       if (opt == EOF) break;
       switch (opt) {
          case 'h':

--- a/openbsd/Battery.c
+++ b/openbsd/Battery.c
@@ -10,6 +10,7 @@ in the source distribution for its full text.
 #include <sys/sysctl.h>
 #include <sys/sensors.h>
 #include <errno.h>
+#include <string.h>
 
 static bool findDevice(const char* name, int* mib, struct sensordev* snsrdev, size_t* sdlen) {
    for (int devn = 0;; devn++) {

--- a/openbsd/Battery.h
+++ b/openbsd/Battery.h
@@ -12,5 +12,4 @@ in the source distribution for its full text.
 
 void Battery_getData(double* level, ACPresence* isOnAC);
 
-
 #endif

--- a/openbsd/OpenBSDProcessList.h
+++ b/openbsd/OpenBSDProcessList.h
@@ -15,7 +15,22 @@ in the source distribution for its full text.
 
 typedef struct CPUData_ {
    unsigned long long int totalTime;
+   unsigned long long int userTime;
+   unsigned long long int niceTime;
+   unsigned long long int sysTime;
+   unsigned long long int sysAllTime;
+   unsigned long long int spinTime;
+   unsigned long long int intrTime;
+   unsigned long long int idleTime;
+
    unsigned long long int totalPeriod;
+   unsigned long long int userPeriod;
+   unsigned long long int nicePeriod;
+   unsigned long long int sysPeriod;
+   unsigned long long int sysAllPeriod;
+   unsigned long long int spinPeriod;
+   unsigned long long int intrPeriod;
+   unsigned long long int idlePeriod;
 } CPUData;
 
 typedef struct OpenBSDProcessList_ {
@@ -51,8 +66,7 @@ char *OpenBSDProcessList_readProcessName(kvm_t* kd, struct kinfo_proc* kproc, in
 /*
  * Taken from OpenBSD's ps(1).
  */
-double getpcpu(const struct kinfo_proc *kp);
-
 void ProcessList_goThroughEntries(ProcessList* this);
+
 
 #endif

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -38,6 +38,7 @@ in the source distribution for its full text.
 #include <fcntl.h>
 #include <kvm.h>
 #include <limits.h>
+#include <math.h>
 
 /*{
 #include "Action.h"
@@ -47,54 +48,6 @@ in the source distribution for its full text.
 extern ProcessFieldData Process_fields[];
 
 }*/
-
-#define MAXCPU 256
-// XXX: probably should be a struct member
-static int64_t old_v[MAXCPU][5];
-
-/*
- * Copyright (c) 1984, 1989, William LeFebvre, Rice University
- * Copyright (c) 1989, 1990, 1992, William LeFebvre, Northwestern University
- *
- * Taken directly from OpenBSD's top(1).
- *
- * percentages(cnt, out, new, old, diffs) - calculate percentage change
- * between array "old" and "new", putting the percentages in "out".
- * "cnt" is size of each array and "diffs" is used for scratch space.
- * The array "old" is updated on each call.
- * The routine assumes modulo arithmetic.  This function is especially
- * useful on BSD machines for calculating cpu state percentages.
- */
-static int percentages(int cnt, int64_t *out, int64_t *new, int64_t *old, int64_t *diffs) {
-   int64_t change, total_change, *dp, half_total;
-   int i;
-
-   /* initialization */
-   total_change = 0;
-   dp = diffs;
-
-   /* calculate changes for each state and the overall change */
-   for (i = 0; i < cnt; i++) {
-      if ((change = *new - *old) < 0) {
-         /* this only happens when the counter wraps */
-         change = INT64_MAX - *old + *new;
-      }
-      total_change += (*dp++ = change);
-      *old++ = *new++;
-   }
-
-   /* avoid divide by zero potential */
-   if (total_change == 0)
-      total_change = 1;
-
-   /* calculate percentages based on overall change, rounding up */
-   half_total = total_change / 2l;
-   for (i = 0; i < cnt; i++)
-      *out++ = ((*diffs++ * 1000 + half_total) / total_change);
-
-   /* return the total in case the caller wants to use it */
-   return (total_change);
-}
 
 ProcessField Platform_defaultFields[] = { PID, USER, PRIORITY, NICE, M_SIZE, M_RESIDENT, STATE, PERCENT_CPU, PERCENT_MEM, TIME, COMM, 0 };
 
@@ -201,43 +154,37 @@ void Platform_getLoadAverage(double* one, double* five, double* fifteen) {
 
 int Platform_getMaxPid() {
    // this is hard-coded in sys/sys/proc.h - no sysctl exists
-   return 32766;
+   return 32766; // XXX Seems changed to 99999, what about using PID_MAX?
 }
 
 double Platform_setCPUValues(Meter* this, int cpu) {
-   int i;
-   double perc;
-
-   OpenBSDProcessList* pl = (OpenBSDProcessList*) this->pl;
-   CPUData* cpuData = &(pl->cpus[cpu]);
-   int64_t new_v[CPUSTATES], diff_v[CPUSTATES], scratch_v[CPUSTATES];
+   const OpenBSDProcessList* pl = (OpenBSDProcessList*) this->pl;
+   const CPUData* cpuData = &(pl->cpus[cpu]);
+   double total = cpuData->totalPeriod == 0 ? 1 : cpuData->totalPeriod;
+   double totalPercent;
    double *v = this->values;
-   size_t size = sizeof(double) * CPUSTATES;
-   int mib[] = { CTL_KERN, KERN_CPTIME2, cpu-1 };
-   if (sysctl(mib, 3, new_v, &size, NULL, 0) == -1) {
-      return 0.;
-   }
 
-   // XXX: why?
-   cpuData->totalPeriod = 1;
-
-   percentages(CPUSTATES, diff_v, new_v,
-         (int64_t *)old_v[cpu-1], scratch_v);
-
-   for (i = 0; i < CPUSTATES; i++) {
-      old_v[cpu-1][i] = new_v[i];
-      v[i] = diff_v[i] / 10.;
-   }
-
-   Meter_setItems(this, 4);
-
-   perc = v[0] + v[1] + v[2] + v[3];
-
-   if (perc <= 100. && perc >= 0.) {
-      return perc;
+   v[CPU_METER_NICE] = cpuData->nicePeriod / total * 100.0;
+   v[CPU_METER_NORMAL] = cpuData->userPeriod / total * 100.0;
+   if (this->pl->settings->detailedCPUTime) {
+      v[CPU_METER_KERNEL]  = cpuData->sysPeriod / total * 100.0;
+      v[CPU_METER_IRQ]     = cpuData->intrPeriod / total * 100.0;
+      v[CPU_METER_SOFTIRQ] = 0.0;
+      v[CPU_METER_STEAL]   = 0.0;
+      v[CPU_METER_GUEST]   = 0.0;
+      v[CPU_METER_IOWAIT]  = 0.0;
+      Meter_setItems(this, 8);
+      totalPercent = v[0]+v[1]+v[2]+v[3];
    } else {
-      return 0.;
+      v[2] = cpuData->sysAllPeriod / total * 100.0;
+      v[3] = 0.0; // No steal nor guest on OpenBSD
+      totalPercent = v[0]+v[1]+v[2];
+      Meter_setItems(this, 4);
    }
+
+   totalPercent = CLAMP(totalPercent, 0.0, 100.0);
+   if (isnan(totalPercent)) totalPercent = 0.0;
+   return totalPercent;
 }
 
 void Platform_setMemoryValues(Meter* this) {

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -20,8 +20,6 @@ in the source distribution for its full text.
 #include "OpenBSDProcess.h"
 #include "OpenBSDProcessList.h"
 
-#include <sys/sched.h>
-#include <uvm/uvmexp.h>
 #include <sys/param.h>
 #include <sys/sysctl.h>
 #include <sys/swap.h>
@@ -31,7 +29,6 @@ in the source distribution for its full text.
 #include <stdint.h>
 #include <string.h>
 #include <sys/types.h>
-#include <sys/sysctl.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <time.h>

--- a/openbsd/Platform.h
+++ b/openbsd/Platform.h
@@ -17,21 +17,6 @@ in the source distribution for its full text.
 extern ProcessFieldData Process_fields[];
 
 
-#define MAXCPU 256
-// XXX: probably should be a struct member
-/*
- * Copyright (c) 1984, 1989, William LeFebvre, Rice University
- * Copyright (c) 1989, 1990, 1992, William LeFebvre, Northwestern University
- *
- * Taken directly from OpenBSD's top(1).
- *
- * percentages(cnt, out, new, old, diffs) - calculate percentage change
- * between array "old" and "new", putting the percentages in "out".
- * "cnt" is size of each array and "diffs" is used for scratch space.
- * The array "old" is updated on each call.
- * The routine assumes modulo arithmetic.  This function is especially
- * useful on BSD machines for calculating cpu state percentages.
- */
 extern ProcessField Platform_defaultFields[];
 
 extern int Platform_numberOfFields;


### PR DESCRIPTION
The current OpenBSD-specific CPU usage code is broken. The `cpu`
parameter of `Platform_setCPUValues` is an integer in the interval
[0, cpuCount], not [0, cpuCount-1]: Actual CPUs are numbered from
1, the “zero” CPU is a “virtual” one which represents the average
of actual CPUs (I guess it’s inherited from Linux’s `/proc/stats`).
This off-by-one error leads to random crashes.

Moreover, the displayed CPU usage is more detailed with system,
user and nice times.

I made the OpenBSD CPU code more similar to the Linux CPU code,
removing a few old bits from OpenBSD’s top(1). I think it will be
easier to understand, maintain and evolve.

I’d love some feedback from experienced OpenBSD people.