### PR TITLE
Fix numbers larger than 100 terabytes

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -228,7 +228,7 @@ void Process_humanNumber(RichString* str, unsigned long number, bool coloring) {
    if(number >= (10 * ONE_DECIMAL_M)) {
       #ifdef __LP64__
       if(number >= (100 * ONE_DECIMAL_G)) {
-         len = snprintf(buffer, 10, "%4ldT ", number / ONE_G);
+         len = snprintf(buffer, 10, "%4luT ", number / ONE_G);
          RichString_appendn(str, largeNumberColor, buffer, len);
          return;
       } else if (number >= (1000 * ONE_DECIMAL_M)) {
@@ -238,7 +238,7 @@ void Process_humanNumber(RichString* str, unsigned long number, bool coloring) {
       }
       #endif
       if(number >= (100 * ONE_DECIMAL_M)) {
-         len = snprintf(buffer, 10, "%4ldG ", number / ONE_M);
+         len = snprintf(buffer, 10, "%4luG ", number / ONE_M);
          RichString_appendn(str, largeNumberColor, buffer, len);
          return;
       }
@@ -246,11 +246,11 @@ void Process_humanNumber(RichString* str, unsigned long number, bool coloring) {
       RichString_appendn(str, largeNumberColor, buffer, len);
       return;
    } else if (number >= 100000) {
-      len = snprintf(buffer, 10, "%4ldM ", number / ONE_K);
+      len = snprintf(buffer, 10, "%4luM ", number / ONE_K);
       RichString_appendn(str, processMegabytesColor, buffer, len);
       return;
    } else if (number >= 1000) {
-      len = snprintf(buffer, 10, "%2ld", number/1000);
+      len = snprintf(buffer, 10, "%2lu", number/1000);
       RichString_appendn(str, processMegabytesColor, buffer, len);
       number %= 1000;
       len = snprintf(buffer, 10, "%03lu ", number);
@@ -278,7 +278,7 @@ void Process_colorNumber(RichString* str, unsigned long long number, bool colori
       int len = snprintf(buffer, 13, "    no perm ");
       RichString_appendn(str, CRT_colors[PROCESS_SHADOW], buffer, len);
    } else if (number > 10000000000) {
-      xSnprintf(buffer, 13, "%11lld ", number / 1000);
+      xSnprintf(buffer, 13, "%11llu ", number / 1000);
       RichString_appendn(str, largeNumberColor, buffer, 5);
       RichString_appendn(str, processMegabytesColor, buffer+5, 3);
       RichString_appendn(str, processColor, buffer+8, 4);
@@ -380,9 +380,9 @@ void Process_writeField(Process* this, RichString* str, ProcessField field) {
    switch (field) {
    case PERCENT_CPU: {
       if (this->percent_cpu > 999.9) {
-         xSnprintf(buffer, n, "%4d ", (unsigned int)this->percent_cpu); 
+         xSnprintf(buffer, n, "%4u ", (unsigned int)this->percent_cpu); 
       } else if (this->percent_cpu > 99.9) {
-         xSnprintf(buffer, n, "%3d. ", (unsigned int)this->percent_cpu); 
+         xSnprintf(buffer, n, "%3u. ", (unsigned int)this->percent_cpu); 
       } else {
          xSnprintf(buffer, n, "%4.1f ", this->percent_cpu);
       }

--- a/Process.c
+++ b/Process.c
@@ -191,10 +191,12 @@ static int Process_getuid = -1;
 #define ONE_K 1024L
 #define ONE_M (ONE_K * ONE_K)
 #define ONE_G (ONE_M * ONE_K)
+#define ONE_T ((long long)ONE_G * ONE_K)
 
 #define ONE_DECIMAL_K 1000L
 #define ONE_DECIMAL_M (ONE_DECIMAL_K * ONE_DECIMAL_K)
 #define ONE_DECIMAL_G (ONE_DECIMAL_M * ONE_DECIMAL_K)
+#define ONE_DECIMAL_T ((long long)ONE_DECIMAL_G * ONE_DECIMAL_K)
 
 char Process_pidFormat[20] = "%7d ";
 
@@ -277,12 +279,15 @@ void Process_colorNumber(RichString* str, unsigned long long number, bool colori
    if ((long long) number == -1LL) {
       int len = snprintf(buffer, 13, "    no perm ");
       RichString_appendn(str, CRT_colors[PROCESS_SHADOW], buffer, len);
-   } else if (number >= 100000000000000) {
-      xSnprintf(buffer, 13, "%11llu ", number / 1000000);
+   } else if (number >= 100000LL * ONE_DECIMAL_T) {
+      xSnprintf(buffer, 13, "%11llu ", number / ONE_DECIMAL_G);
+      RichString_appendn(str, largeNumberColor, buffer, 12);
+   } else if (number >= 100LL * ONE_DECIMAL_T) {
+      xSnprintf(buffer, 13, "%11llu ", number / ONE_DECIMAL_M);
       RichString_appendn(str, largeNumberColor, buffer, 8);
       RichString_appendn(str, processMegabytesColor, buffer+8, 4);
-   } else if (number >= 10000000000) {
-      xSnprintf(buffer, 13, "%11llu ", number / 1000);
+   } else if (number >= 10LL * ONE_DECIMAL_G) {
+      xSnprintf(buffer, 13, "%11llu ", number / ONE_DECIMAL_K);
       RichString_appendn(str, largeNumberColor, buffer, 5);
       RichString_appendn(str, processMegabytesColor, buffer+5, 3);
       RichString_appendn(str, processColor, buffer+8, 4);
@@ -362,14 +367,17 @@ void Process_outputRate(RichString* str, char* buffer, int n, double rate, int c
    } else if (rate < ONE_K) {
       int len = snprintf(buffer, n, "%7.2f B/s ", rate);
       RichString_appendn(str, processColor, buffer, len);
-   } else if (rate < ONE_K * ONE_K) {
+   } else if (rate < ONE_M) {
       int len = snprintf(buffer, n, "%7.2f K/s ", rate / ONE_K);
       RichString_appendn(str, processColor, buffer, len);
-   } else if (rate < ONE_K * ONE_K * ONE_K) {
-      int len = snprintf(buffer, n, "%7.2f M/s ", rate / ONE_K / ONE_K);
+   } else if (rate < ONE_G) {
+      int len = snprintf(buffer, n, "%7.2f M/s ", rate / ONE_M);
       RichString_appendn(str, processMegabytesColor, buffer, len);
+   } else if (rate < ONE_T) {
+      int len = snprintf(buffer, n, "%7.2f G/s ", rate / ONE_G);
+      RichString_appendn(str, largeNumberColor, buffer, len);
    } else {
-      int len = snprintf(buffer, n, "%7.2f G/s ", rate / ONE_K / ONE_K / ONE_K);
+      int len = snprintf(buffer, n, "%7.2f T/s ", rate / ONE_T);
       RichString_appendn(str, largeNumberColor, buffer, len);
    }
 }

--- a/Process.c
+++ b/Process.c
@@ -277,7 +277,11 @@ void Process_colorNumber(RichString* str, unsigned long long number, bool colori
    if ((long long) number == -1LL) {
       int len = snprintf(buffer, 13, "    no perm ");
       RichString_appendn(str, CRT_colors[PROCESS_SHADOW], buffer, len);
-   } else if (number > 10000000000) {
+   } else if (number >= 100000000000000) {
+      xSnprintf(buffer, 13, "%11llu ", number / 1000000);
+      RichString_appendn(str, largeNumberColor, buffer, 8);
+      RichString_appendn(str, processMegabytesColor, buffer+8, 4);
+   } else if (number >= 10000000000) {
       xSnprintf(buffer, 13, "%11llu ", number / 1000);
       RichString_appendn(str, largeNumberColor, buffer, 5);
       RichString_appendn(str, processMegabytesColor, buffer+5, 3);

--- a/Process.h
+++ b/Process.h
@@ -166,10 +166,12 @@ typedef struct ProcessClass_ {
 #define ONE_K 1024L
 #define ONE_M (ONE_K * ONE_K)
 #define ONE_G (ONE_M * ONE_K)
+#define ONE_T ((long long)ONE_G * ONE_K)
 
 #define ONE_DECIMAL_K 1000L
 #define ONE_DECIMAL_M (ONE_DECIMAL_K * ONE_DECIMAL_K)
 #define ONE_DECIMAL_G (ONE_DECIMAL_M * ONE_DECIMAL_K)
+#define ONE_DECIMAL_T ((long long)ONE_DECIMAL_G * ONE_DECIMAL_K)
 
 extern char Process_pidFormat[20];
 

--- a/ScreenManager.c
+++ b/ScreenManager.c
@@ -145,14 +145,12 @@ static void checkRecalculation(ScreenManager* this, double* oldTime, int* sortTi
 }
 
 static void ScreenManager_drawPanels(ScreenManager* this, int focus) {
-   int nPanels = this->panelCount;
+   const int nPanels = this->panelCount;
    for (int i = 0; i < nPanels; i++) {
       Panel* panel = (Panel*) Vector_get(this->panels, i);
       Panel_draw(panel, i == focus);
-      if (i < nPanels) {
-         if (this->orientation == HORIZONTAL) {
-            mvvline(panel->y, panel->x+panel->w, ' ', panel->h+1);
-         }
+      if (this->orientation == HORIZONTAL) {
+         mvvline(panel->y, panel->x+panel->w, ' ', panel->h+1);
       }
    }
 }

--- a/darwin/DarwinProcessList.c
+++ b/darwin/DarwinProcessList.c
@@ -84,9 +84,8 @@ void ProcessList_freeCPULoadInfo(processor_cpu_load_info_t *p) {
        if(0 != munmap(*p, vm_page_size)) {
            CRT_fatalError("Unable to free old CPU load information\n");
        }
+       *p = NULL;
    }
-
-   *p = NULL;
 }
 
 unsigned ProcessList_allocateCPULoadInfo(processor_cpu_load_info_t *p) {

--- a/htop.c
+++ b/htop.c
@@ -87,13 +87,12 @@ static CommandLineSettings parseArguments(int argc, char** argv) {
       {"no-colour",no_argument,         0, 'C'},
       {"tree",     no_argument,         0, 't'},
       {"pid",      required_argument,   0, 'p'},
-      {"io",       no_argument,         0, 'i'},
       {0,0,0,0}
    };
 
    int opt, opti=0;
    /* Parse arguments */
-   while ((opt = getopt_long(argc, argv, "hvCs:td:u:p:i", long_opts, &opti))) {
+   while ((opt = getopt_long(argc, argv, "hvCs:td:u:p:", long_opts, &opti))) {
       if (opt == EOF) break;
       switch (opt) {
          case 'h':


### PR DESCRIPTION
This is an issue similar to #733. If a process has `RD_CHAR` or `WR_CHAR` larger than 100 TB, and the columns are displayed, htop will terminate and print `htop: Success`.

The situation can be reproduced by running something that calls `read`/`write` a lot for a few hours, such as `cat /dev/zero > /dev/null`.