### PR TITLE
Fix configure 'major' check causing <sys/sysmacros.h> to miss.

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -8,6 +8,8 @@ in the source distribution for its full text.
 #include "Process.h"
 #include "Settings.h"
 
+#include "config.h"
+
 #include "CRT.h"
 #include "StringUtils.h"
 #include "RichString.h"

--- a/configure.ac
+++ b/configure.ac
@@ -69,7 +69,7 @@ dnl glibc 2.25 deprecates 'major' and 'minor' in <sys/types.h> and requires to
 dnl include <sys/sysmacros.h>. However the logic in AC_HEADER_MAJOR has not yet
 dnl been updated in Autoconf 2.69, so use a workaround:
 m4_version_prereq([2.70], [],
-[if test "x$ac_cv_header_sys_mkdev_h" = xno; then
+[if test "x$ac_cv_header_sys_mkdev_h" != xyes; then
    AC_CHECK_HEADER(sys/sysmacros.h, [AC_DEFINE(MAJOR_IN_SYSMACROS, 1,
       [Define to 1 if `major', `minor', and `makedev' are declared in <sys/sysmacros.h>.])])
 fi])


### PR DESCRIPTION
A logic mistake in pull request #746 causes <sys/sysmacro.h> to be
*not* included when AC_HEADER_MAJOR (before autoconf-2.70) finds
'major' in <sys/types.h>. Though this would still build htop, it would
still bring deprecation warning in systems using glibc 2.25-2.27. Fix
the logic and suppress the warning.

Also, include config.h in Process.c for the sake of strengthening the
code.

(This should supersede pull request #867. Thanks @wataash for discovering this.)