### PR TITLE
Truncate overwide jail names on BSD.

### DIFF
--- a/dragonflybsd/DragonFlyBSDProcess.c
+++ b/dragonflybsd/DragonFlyBSDProcess.c
@@ -121,7 +121,7 @@ void DragonFlyBSDProcess_writeField(Process* this, RichString* str, ProcessField
    case PID: xSnprintf(buffer, n, Process_pidFormat, (fp->kernel ? -1 : this->pid)); break;
    case JID: xSnprintf(buffer, n, Process_pidFormat, fp->jid); break;
    case JAIL:{
-      xSnprintf(buffer, n, "%-11s ", fp->jname); break;
+      xSnprintf(buffer, n, "%-11s ", fp->jname);
       if (buffer[11] != '\0') {
          buffer[11] = ' ';
          buffer[12] = '\0';

--- a/freebsd/FreeBSDProcess.c
+++ b/freebsd/FreeBSDProcess.c
@@ -119,7 +119,7 @@ void FreeBSDProcess_writeField(Process* this, RichString* str, ProcessField fiel
    // add FreeBSD-specific fields here
    case JID: xSnprintf(buffer, n, Process_pidFormat, fp->jid); break;
    case JAIL:{
-      xSnprintf(buffer, n, "%-11s ", fp->jname); break;
+      xSnprintf(buffer, n, "%-11s ", fp->jname);
       if (buffer[11] != '\0') {
          buffer[11] = ' ';
          buffer[12] = '\0';


### PR DESCRIPTION
Jail names longer than eleven characters spill into adjacent columns and mess up the alignment.