### PR TITLE
Close pipe after lsof

### DIFF
--- a/OpenFilesScreen.c
+++ b/OpenFilesScreen.c
@@ -124,6 +124,7 @@ static OpenFiles_ProcessData* OpenFilesScreen_getProcessData(pid_t pid) {
       item->data[cmd] = xStrdup(line + 1);
       free(line);
    }
+   fclose(fd);
    int wstatus;
    if (waitpid(child, &wstatus, 0) == -1) {
       pdata->error = 1;


### PR DESCRIPTION
When `htop` runs `lsof`, it leaves the read end of the pipe open. You can see this by selecting the htop process itself, pressing `l`, and then pressing `F5`/`Refresh` repeatedly. Every time it refreshes, there's 1 more pipe fd in the table until `RLIMIT_NOFILE` is reached. This commit fixes that.