### PR TITLE
Add bindep.txt file

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,4 @@
+gcc
+make
+ncurses-libs
+ncurses-devel


### PR DESCRIPTION
Mentions binary dependencies and can be used to simplify their
installation.

Fixes: #924