### PR TITLE
Settings.c: show thread names by default

### DIFF
--- a/Settings.c
+++ b/Settings.c
@@ -332,7 +332,7 @@ Settings* Settings_new(int cpuCount) {
    this->direction = 1;
    this->hideThreads = false;
    this->shadowOtherUsers = false;
-   this->showThreadNames = false;
+   this->showThreadNames = true;
    this->hideKernelThreads = false;
    this->hideUserlandThreads = false;
    this->treeView = false;


### PR DESCRIPTION
This is to support analysis of multi-threaded applications "out of the
box", like web browsers. Applications can name their threads, so this
change should prove useful.

The htoprc file is written to whenever the user changes settings in
htop. htoprc settings take precedence over this change.

Signed-off-by: Joe Konno <joe.konno@intel.com>