### PR TITLE
Add new display option to also show CPU frequency in CPU meters.

### DIFF
--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -65,18 +65,18 @@ static void CPUMeter_updateValues(Meter* this, char* buffer, int size) {
    memset(this->values, 0, sizeof(double) * CPU_METER_ITEMCOUNT);
    double percent = Platform_setCPUValues(this, cpu);
    if (cpu != 0 && this->pl->settings->showCPUFrequency) {
-      /* Initial frequency is in KHz. Divide it by 1024 till it's less than 1024, and emit unit accordingly */
+      /* Initial frequency is in KHz. Divide it by 1000 till it's less than 1000, and emit unit accordingly */
       double cpuFrequency = this->values[CPU_METER_FREQUENCY];
       char unit = 'K';
-      if (cpuFrequency > 1024) {
-         cpuFrequency /= 1024;
+      if (cpuFrequency > 1000) {
+         cpuFrequency /= 1000;
          unit = 'M';
       }
-      if (cpuFrequency > 1024) {
-         cpuFrequency /= 1024;
+      if (cpuFrequency > 1000) {
+         cpuFrequency /= 1000;
          unit = 'G';
       }
-      xSnprintf(buffer, size, "%5.1f%% %.1f%cHz", percent, cpuFrequency, unit);
+      xSnprintf(buffer, size, "%5.1f%% %.3f%cHz", percent, cpuFrequency, unit);
    } else {
       xSnprintf(buffer, size, "%5.1f%%", percent);
    }

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -68,18 +68,24 @@ static void CPUMeter_updateValues(Meter* this, char* buffer, int size) {
       /* Initial frequency is in KHz. Divide it by 1000 till it's less than 1000, and emit unit accordingly */
       double cpuFrequency = this->values[CPU_METER_FREQUENCY];
       char unit = 'K';
-      if (cpuFrequency > 1000) {
-         cpuFrequency /= 1000;
-         unit = 'M';
-      }
-      if (cpuFrequency > 1000) {
-         cpuFrequency /= 1000;
-         unit = 'G';
+      char cpuFrequencyBuffer[16];
+      if (cpuFrequency < 0) {
+         xSnprintf(cpuFrequencyBuffer, sizeof(cpuFrequencyBuffer), "N/A");
+      } else {
+         if (cpuFrequency > 1000) {
+            cpuFrequency /= 1000;
+            unit = 'M';
+         }
+         if (cpuFrequency > 1000) {
+            cpuFrequency /= 1000;
+            unit = 'G';
+         }
+         xSnprintf(cpuFrequencyBuffer, 15, "%.3f%cHz", cpuFrequency, unit);
       }
       if (this->pl->settings->showCPUUsage) {
-         xSnprintf(buffer, size, "%5.1f%% %.3f%cHz", percent, cpuFrequency, unit);
+         xSnprintf(buffer, size, "%5.1f%% %s", percent, cpuFrequencyBuffer);
       } else {
-         xSnprintf(buffer, size, "%.3f%cHz", cpuFrequency, unit);
+         xSnprintf(buffer, size, "%s", cpuFrequencyBuffer);
       }
    } else if (this->pl->settings->showCPUUsage) {
       xSnprintf(buffer, size, "%5.1f%%", percent);

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -64,18 +64,14 @@ static void CPUMeter_updateValues(Meter* this, char* buffer, int size) {
    }
    memset(this->values, 0, sizeof(double) * CPU_METER_ITEMCOUNT);
    double percent = Platform_setCPUValues(this, cpu);
-   if (cpu != 0 && this->pl->settings->showCPUFrequency) {
-      /* Initial frequency is in KHz. Divide it by 1000 till it's less than 1000, and emit unit accordingly */
+   if (this->pl->settings->showCPUFrequency) {
+      /* Initial frequency is in MHz. Emit it as GHz if it's larger than 1000MHz */
       double cpuFrequency = this->values[CPU_METER_FREQUENCY];
-      char unit = 'K';
+      char unit = 'M';
       char cpuFrequencyBuffer[16];
       if (cpuFrequency < 0) {
          xSnprintf(cpuFrequencyBuffer, sizeof(cpuFrequencyBuffer), "N/A");
       } else {
-         if (cpuFrequency > 1000) {
-            cpuFrequency /= 1000;
-            unit = 'M';
-         }
          if (cpuFrequency > 1000) {
             cpuFrequency /= 1000;
             unit = 'G';

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -76,9 +76,15 @@ static void CPUMeter_updateValues(Meter* this, char* buffer, int size) {
          cpuFrequency /= 1000;
          unit = 'G';
       }
-      xSnprintf(buffer, size, "%5.1f%% %.3f%cHz", percent, cpuFrequency, unit);
-   } else {
+      if (this->pl->settings->showCPUUsage) {
+         xSnprintf(buffer, size, "%5.1f%% %.3f%cHz", percent, cpuFrequency, unit);
+      } else {
+         xSnprintf(buffer, size, "%.3f%cHz", cpuFrequency, unit);
+      }
+   } else if (this->pl->settings->showCPUUsage) {
       xSnprintf(buffer, size, "%5.1f%%", percent);
+   } else if (size > 0) {
+      buffer[0] = '\0';
    }
 }
 

--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -80,7 +80,7 @@ static void CPUMeter_updateValues(Meter* this, char* buffer, int size) {
             cpuFrequency /= 1000;
             unit = 'G';
          }
-         xSnprintf(cpuFrequencyBuffer, 15, "%.3f%cHz", cpuFrequency, unit);
+         xSnprintf(cpuFrequencyBuffer, sizeof(cpuFrequencyBuffer), "%.3f%cHz", cpuFrequency, unit);
       }
       if (this->pl->settings->showCPUUsage) {
          xSnprintf(buffer, size, "%5.1f%% %s", percent, cpuFrequencyBuffer);

--- a/CPUMeter.h
+++ b/CPUMeter.h
@@ -20,7 +20,8 @@ typedef enum {
    CPU_METER_STEAL = 5,
    CPU_METER_GUEST = 6,
    CPU_METER_IOWAIT = 7,
-   CPU_METER_ITEMCOUNT = 8, // number of entries in this enum
+   CPU_METER_FREQUENCY = 8,
+   CPU_METER_ITEMCOUNT = 9, // number of entries in this enum
 } CPUMeterValues;
 
 

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -97,5 +97,6 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Count CPUs from 0 instead of 1"), &(settings->countCPUsFromZero)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Update process names on every refresh"), &(settings->updateProcessNames)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Add guest time in CPU meter percentage"), &(settings->accountGuestInCPUMeter)));
+   Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Also show CPU frequency"), &(settings->showCPUFrequency)));
    return this;
 }

--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -97,6 +97,7 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Count CPUs from 0 instead of 1"), &(settings->countCPUsFromZero)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Update process names on every refresh"), &(settings->updateProcessNames)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Add guest time in CPU meter percentage"), &(settings->accountGuestInCPUMeter)));
+   Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Also show CPU percentage numerically"), &(settings->showCPUUsage)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Also show CPU frequency"), &(settings->showCPUFrequency)));
    return this;
 }

--- a/Settings.c
+++ b/Settings.c
@@ -45,6 +45,7 @@ typedef struct Settings_ {
 
    bool countCPUsFromZero;
    bool detailedCPUTime;
+   bool showCPUFrequency;
    bool treeView;
    bool showProgramPath;
    bool hideThreads;
@@ -223,6 +224,8 @@ static bool Settings_read(Settings* this, const char* fileName) {
          this->detailedCPUTime = atoi(option[1]);
       } else if (String_eq(option[0], "cpu_count_from_zero")) {
          this->countCPUsFromZero = atoi(option[1]);
+      } else if (String_eq(option[0], "show_cpu_frequency")) {
+         this->showCPUFrequency = atoi(option[1]);
       } else if (String_eq(option[0], "update_process_names")) {
          this->updateProcessNames = atoi(option[1]);
       } else if (String_eq(option[0], "account_guest_in_cpu_meter")) {
@@ -312,6 +315,7 @@ bool Settings_write(Settings* this) {
    fprintf(fd, "header_margin=%d\n", (int) this->headerMargin);
    fprintf(fd, "detailed_cpu_time=%d\n", (int) this->detailedCPUTime);
    fprintf(fd, "cpu_count_from_zero=%d\n", (int) this->countCPUsFromZero);
+   fprintf(fd, "show_cpu_frequency=%d\n", (int) this->showCPUFrequency);
    fprintf(fd, "update_process_names=%d\n", (int) this->updateProcessNames);
    fprintf(fd, "account_guest_in_cpu_meter=%d\n", (int) this->accountGuestInCPUMeter);
    fprintf(fd, "color_scheme=%d\n", (int) this->colorScheme);
@@ -340,6 +344,7 @@ Settings* Settings_new(int cpuCount) {
    this->highlightMegabytes = false;
    this->detailedCPUTime = false;
    this->countCPUsFromZero = false;
+   this->showCPUFrequency = false;
    this->updateProcessNames = false;
    this->cpuCount = cpuCount;
    this->showProgramPath = true;

--- a/Settings.c
+++ b/Settings.c
@@ -45,6 +45,7 @@ typedef struct Settings_ {
 
    bool countCPUsFromZero;
    bool detailedCPUTime;
+   bool showCPUUsage;
    bool showCPUFrequency;
    bool treeView;
    bool showProgramPath;
@@ -224,6 +225,8 @@ static bool Settings_read(Settings* this, const char* fileName) {
          this->detailedCPUTime = atoi(option[1]);
       } else if (String_eq(option[0], "cpu_count_from_zero")) {
          this->countCPUsFromZero = atoi(option[1]);
+      } else if (String_eq(option[0], "show_cpu_usage")) {
+         this->showCPUUsage = atoi(option[1]);
       } else if (String_eq(option[0], "show_cpu_frequency")) {
          this->showCPUFrequency = atoi(option[1]);
       } else if (String_eq(option[0], "update_process_names")) {
@@ -315,6 +318,7 @@ bool Settings_write(Settings* this) {
    fprintf(fd, "header_margin=%d\n", (int) this->headerMargin);
    fprintf(fd, "detailed_cpu_time=%d\n", (int) this->detailedCPUTime);
    fprintf(fd, "cpu_count_from_zero=%d\n", (int) this->countCPUsFromZero);
+   fprintf(fd, "show_cpu_usage=%d\n", (int) this->showCPUUsage);
    fprintf(fd, "show_cpu_frequency=%d\n", (int) this->showCPUFrequency);
    fprintf(fd, "update_process_names=%d\n", (int) this->updateProcessNames);
    fprintf(fd, "account_guest_in_cpu_meter=%d\n", (int) this->accountGuestInCPUMeter);
@@ -344,6 +348,7 @@ Settings* Settings_new(int cpuCount) {
    this->highlightMegabytes = false;
    this->detailedCPUTime = false;
    this->countCPUsFromZero = false;
+   this->showCPUUsage = true;
    this->showCPUFrequency = false;
    this->updateProcessNames = false;
    this->cpuCount = cpuCount;

--- a/Settings.h
+++ b/Settings.h
@@ -36,6 +36,7 @@ typedef struct Settings_ {
 
    bool countCPUsFromZero;
    bool detailedCPUTime;
+   bool showCPUUsage;
    bool showCPUFrequency;
    bool treeView;
    bool showProgramPath;

--- a/Settings.h
+++ b/Settings.h
@@ -36,6 +36,7 @@ typedef struct Settings_ {
 
    bool countCPUsFromZero;
    bool detailedCPUTime;
+   bool showCPUFrequency;
    bool treeView;
    bool showProgramPath;
    bool hideThreads;

--- a/darwin/Platform.c
+++ b/darwin/Platform.c
@@ -217,6 +217,8 @@ double Platform_setCPUValues(Meter* mtr, int cpu) {
    /* Convert to percent and return */
    total = mtr->values[CPU_METER_NICE] + mtr->values[CPU_METER_NORMAL] + mtr->values[CPU_METER_KERNEL];
 
+   mtr->values[CPU_METER_FREQUENCY] = -1;
+
    return CLAMP(total, 0.0, 100.0);
 }
 

--- a/dragonflybsd/Platform.c
+++ b/dragonflybsd/Platform.c
@@ -179,6 +179,9 @@ double Platform_setCPUValues(Meter* this, int cpu) {
 
    percent = CLAMP(percent, 0.0, 100.0);
    if (isnan(percent)) percent = 0.0;
+
+   v[CPU_METER_FREQUENCY] = -1;
+
    return percent;
 }
 

--- a/freebsd/Platform.c
+++ b/freebsd/Platform.c
@@ -178,6 +178,9 @@ double Platform_setCPUValues(Meter* this, int cpu) {
 
    percent = CLAMP(percent, 0.0, 100.0);
    if (isnan(percent)) percent = 0.0;
+
+   v[CPU_METER_FREQUENCY] = -1;
+
    return percent;
 }
 

--- a/linux/LinuxProcessList.h
+++ b/linux/LinuxProcessList.h
@@ -48,6 +48,8 @@ typedef struct CPUData_ {
    unsigned long long int softIrqPeriod;
    unsigned long long int stealPeriod;
    unsigned long long int guestPeriod;
+
+   double frequency;
 } CPUData;
 
 typedef struct TtyDriver_ {
@@ -71,6 +73,10 @@ typedef struct LinuxProcessList_ {
 
 #ifndef PROCDIR
 #define PROCDIR "/proc"
+#endif
+
+#ifndef PROCCPUINFOFILE
+#define PROCCPUINFOFILE PROCDIR "/cpuinfo"
 #endif
 
 #ifndef PROCSTATFILE

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -192,6 +192,22 @@ double Platform_setCPUValues(Meter* this, int cpu) {
    }
    percent = CLAMP(percent, 0.0, 100.0);
    if (isnan(percent)) percent = 0.0;
+
+   v[CPU_METER_FREQUENCY] = 0;
+   if (this->pl->settings->showCPUFrequency) {
+      char filename[63+1];
+      xSnprintf(filename, 63, "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq", cpu - 1);
+      FILE* fd = fopen(filename, "r");
+      if (fd) {
+         unsigned int cpuFrequency;
+         int n = fscanf(fd, "%u", &cpuFrequency);
+         fclose(fd);
+         if (n > 0) {
+            v[CPU_METER_FREQUENCY] = cpuFrequency;
+         }
+      }
+   }
+
    return percent;
 }
 

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -193,20 +193,7 @@ double Platform_setCPUValues(Meter* this, int cpu) {
    percent = CLAMP(percent, 0.0, 100.0);
    if (isnan(percent)) percent = 0.0;
 
-   v[CPU_METER_FREQUENCY] = -1;
-   if (this->pl->settings->showCPUFrequency) {
-      char filename[64];
-      xSnprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq", cpu - 1);
-      FILE* fd = fopen(filename, "r");
-      if (fd) {
-         unsigned int cpuFrequency;
-         int n = fscanf(fd, "%u", &cpuFrequency);
-         fclose(fd);
-         if (n > 0) {
-            v[CPU_METER_FREQUENCY] = cpuFrequency;
-         }
-      }
-   }
+   v[CPU_METER_FREQUENCY] = cpuData->frequency;
 
    return percent;
 }

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -193,10 +193,10 @@ double Platform_setCPUValues(Meter* this, int cpu) {
    percent = CLAMP(percent, 0.0, 100.0);
    if (isnan(percent)) percent = 0.0;
 
-   v[CPU_METER_FREQUENCY] = 0;
+   v[CPU_METER_FREQUENCY] = -1;
    if (this->pl->settings->showCPUFrequency) {
-      char filename[63+1];
-      xSnprintf(filename, 63, "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq", cpu - 1);
+      char filename[64];
+      xSnprintf(filename, sizeof(filename), "/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq", cpu - 1);
       FILE* fd = fopen(filename, "r");
       if (fd) {
          unsigned int cpuFrequency;

--- a/openbsd/Platform.c
+++ b/openbsd/Platform.c
@@ -233,6 +233,8 @@ double Platform_setCPUValues(Meter* this, int cpu) {
 
    perc = v[0] + v[1] + v[2] + v[3];
 
+   v[CPU_METER_FREQUENCY] = -1;
+
    if (perc <= 100. && perc >= 0.) {
       return perc;
    } else {

--- a/solaris/Platform.c
+++ b/solaris/Platform.c
@@ -203,6 +203,9 @@ double Platform_setCPUValues(Meter* this, int cpu) {
 
    percent = CLAMP(percent, 0.0, 100.0);
    if (isnan(percent)) percent = 0.0;
+
+   v[CPU_METER_FREQUENCY] = -1;
+
    return percent;
 }
 

--- a/unsupported/Platform.c
+++ b/unsupported/Platform.c
@@ -108,8 +108,11 @@ int Platform_getMaxPid() {
 }
 
 double Platform_setCPUValues(Meter* this, int cpu) {
-   (void) this;
    (void) cpu;
+
+   double* v = this->values;
+   v[CPU_METER_FREQUENCY] = -1;
+
    return 0.0;
 }
 


### PR DESCRIPTION
The option is only implemented on Linux. On other platforms, and on Linuxes
that do not expose the relevant sysfs file, the frequency will be "N/A".

There is also a new option to show the CPU usage number from the meter,
which defaults to true but can be disabled to hide the numeric display.

---

~~Unlike #592, this uses the per-CPU sysfs file to directly read an unsigned int.~~ Like #592, this uses `/proc/cpuinfo` instead of the per-CPU sysfs `scaling_cur_freq` files. The latter are slow to read, as documented [here.](https://github.com/hishamhm/htop/pull/932#issuecomment-520197726)

Also it defaults to appending the frequency to the usage percentage rather than replacing it, but provides an option to replace it by hiding the usage percentage.

Open questions:

- [x] ~~Is there demand to hide the usage percentage and just show the CPU frequency? I wouldn't have thought of it, but given #592 perhaps someone would want it?~~ Implemented per demand.

- [x] ~~Is there demand for the average CPU meter to show an average frequency? (I personally don't see the point.)~~ Implemented.

- [x] ~~Should there be any pre-checks to avoid presenting the display option to the user in the first place? Say if they're not on Linux (where it isn't implemented), or they are but `/sys/.../cpu0/cpufreq/scaling_cur_freq` doesn't exist. May be useful to avoid confusion from seeing "0KHz".~~ The meter now says "N/A" in these situations which should not be confusing, and MichaIng raised a good point that a disappearing display option could be more confusing.