### PR TITLE
suggestion: make MainFunctions less densely packed

### DIFF
--- a/MainPanel.c
+++ b/MainPanel.c
@@ -36,7 +36,7 @@ typedef bool(*MainPanel_ForeachProcessFn)(Process*, Arg);
 
 }*/
 
-static const char* const MainFunctions[]  = {"Help  ", "Setup ", "Search", "Filter", "Tree  ", "SortBy", "Nice -", "Nice +", "Kill  ", "Quit  ", NULL};
+static const char* const MainFunctions[]  = {"Help   ", "Setup  ", "Search ", "Filter ", "Tree   ", "SortBy ", "Nice - ", "Nice + ", "Kill   ", "Quit   ", NULL};
 
 void MainPanel_updateTreeFunctions(MainPanel* this, bool mode) {
    FunctionBar* bar = MainPanel_getFunctionBar(this);


### PR DESCRIPTION
Currently, for example 'search' and 'filter' look very tightly put together. This might confuse some users which F{1-10} relates to which function.
To resolve this while preserving equal spacing, increase all functions width to seven characters.