### PR TITLE
Htop column padding for v2.2.0

### DIFF
--- a/Process.c
+++ b/Process.c
@@ -157,6 +157,7 @@ typedef struct ProcessFieldData_ {
    const char* title;
    const char* description;
    int flags;
+   int width;
 } ProcessFieldData;
 
 // Implemented in platform-specific code:
@@ -211,6 +212,9 @@ void Process_setupColumnWidths() {
       Process_fields[Process_pidColumns[i].id].title = Process_titleBuffer[i];
    }
    xSnprintf(Process_pidFormat, sizeof(Process_pidFormat), "%%%dd ", digits);
+   for (int i = 0; i != LAST_PROCESSFIELD; ++i) {
+       Process_fields[i].width = -1;
+   }
 }
 
 void Process_humanNumber(RichString* str, unsigned long number, bool coloring) {
@@ -479,15 +483,20 @@ void Process_writeField(Process* this, RichString* str, ProcessField field) {
       } else {
          xSnprintf(buffer, n, "%-9d ", this->st_uid);
       }
-      if (buffer[9] != '\0') {
-         buffer[9] = ' ';
-         buffer[10] = '\0';
-      }
       break;
    }
    default:
       xSnprintf(buffer, n, "- ");
    }
+
+   if (Process_fields[field].width > 0) {
+      char* dummy;
+      if (asprintf(&dummy, "%-*s", Process_fields[field].width, buffer) != -1) {
+         strcpy(buffer, dummy);
+         free(dummy);
+      }
+   }
+
    RichString_append(str, attr, buffer);
 }
 

--- a/Process.h
+++ b/Process.h
@@ -135,6 +135,7 @@ typedef struct ProcessFieldData_ {
    const char* title;
    const char* description;
    int flags;
+   int width;
 } ProcessFieldData;
 
 // Implemented in platform-specific code:

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -128,6 +128,12 @@ void ProcessList_printHeader(ProcessList* this, RichString* header) {
    for (int i = 0; fields[i]; i++) {
       const char* field = Process_fields[fields[i]].title;
       if (!field) field = "- ";
+         if (Process_fields[fields[i]].width > 0) {
+         char* dummy;
+         if (asprintf(&dummy, "%-*s", Process_fields[fields[i]].width, field) != -1) {
+            field = dummy;
+         }
+      }
       if (!this->settings->treeView && this->settings->sortKey == fields[i])
          RichString_append(header, CRT_colors[PANEL_SELECTION_FOCUS], field);
       else

--- a/Settings.c
+++ b/Settings.c
@@ -244,8 +244,24 @@ static bool Settings_read(Settings* this, const char* fileName) {
       } else if (String_eq(option[0], "right_meter_modes")) {
          Settings_readMeterModes(this, option[1], 1);
          didReadMeters = true;
-      }
+      } else if (String_eq(option[0], "column_padding")) {
+        int nData;
+        char** data = String_split(option[1], ':', &nData);
+        if (data) {
+           if (nData >= 2) {
+              for (int i = 0; i != LAST_PROCESSFIELD; ++i) {
+                 if (!Process_fields[i].name) {
+                    continue;
+                 }
+                 if (!strcmp(Process_fields[i].name, data[0])) {
+                    Process_fields[i].width = atoi(data[1]);
+                 }
+              }
+           }
+           String_freeArray(data);
+        }
       String_freeArray(option);
+     }
    }
    fclose(fd);
    if (!didReadMeters) {

--- a/Settings.c
+++ b/Settings.c
@@ -336,6 +336,12 @@ bool Settings_write(Settings* this) {
    fprintf(fd, "left_meter_modes="); writeMeterModes(this, fd, 0);
    fprintf(fd, "right_meters="); writeMeters(this, fd, 1);
    fprintf(fd, "right_meter_modes="); writeMeterModes(this, fd, 1);
+   for (int i = 0; i != LAST_PROCESSFIELD; ++i) {
+      if (Process_fields[i].width <= 0) {
+        continue;
+     }
+     fprintf(fd, "column_padding=%s:%d\n", Process_fields[i].name, Process_fields[i].width);
+   }
    fclose(fd);
    return true;
 }

--- a/linux/LinuxProcess.c
+++ b/linux/LinuxProcess.c
@@ -143,7 +143,7 @@ typedef struct LinuxProcess_ {
 } LinuxProcess;
 
 #ifndef Process_isKernelThread
-#define Process_isKernelThread(_process) ((LinuxProcess*)(_process)->isKernelThread)
+#define Process_isKernelThread(_process) (((LinuxProcess*)(_process))->isKernelThread)
 #endif
 
 #ifndef Process_isUserlandThread
@@ -398,6 +398,14 @@ void LinuxProcess_writeField(Process* this, RichString* str, ProcessField field)
    default:
       Process_writeField((Process*)this, str, field);
       return;
+   }
+
+   if (Process_fields[field].width > 0) {
+      char* dummy;
+      if (asprintf(&dummy, "%-*s", Process_fields[field].width, buffer) != -1) {
+         strcpy(buffer, dummy);
+         free(dummy);
+      }
    }
    RichString_append(str, attr, buffer);
 }


### PR DESCRIPTION
This PR allows adapting the column width via global or local htoprc.

Just write
`column_padding=[COLUMN_NAME]:[WIDTH)`
e.g.
`column_padding=USER:20`
to have the column 20 chars wide (right padded with spaces).

Attention: Using more than 255 chars as padding can lead to segfaults (but should not be useful).