### PR TITLE
Properly identify zombie processes

### DIFF
--- a/linux/LinuxProcessList.c
+++ b/linux/LinuxProcessList.c
@@ -692,7 +692,11 @@ static bool LinuxProcessList_readCmdlineFile(Process* process, const char* dirna
    int tokenEnd = 0; 
    int lastChar = 0;
    if (amtRead == 0) {
-      ((LinuxProcess*)process)->isKernelThread = true;
+      if (process->state == 'Z') {
+         process->basenameOffset = 0;
+      } else {
+         ((LinuxProcess*)process)->isKernelThread = true;
+      }
       return true;
    } else if (amtRead < 0) {
       return false;


### PR DESCRIPTION
I suggest the following small fix with the following reasoning:

- the conditionals with `amtRead` in function `LinuxProcessList_readCmdlineFile` are meant to protect the execution of the for loop (and what follows it), which is not supposed to be run with `amtRead == 0` (if I understand correctly),
- the command for zombie processes is then set in function `LinuxProcessList_recurseProcTree` at line [883](https://github.com/hishamhm/htop/blob/402e46bb82964366746b86d77eb5afa69c279539/linux/LinuxProcessList.c#L883) after the "offending" call to `LinuxProcessList_readCmdlineFile` at line [856](https://github.com/hishamhm/htop/blob/402e46bb82964366746b86d77eb5afa69c279539/linux/LinuxProcessList.c#L856).

To me this is a quick fix and the setting of command name of processes seems a little bit clumsy (i.e. `readCmdlineFile` is not just reading, but actually setting the command name of a process and classifying it as a kernel thread), however, I lack the insight as well as experience to write it better. Maybe setting the command name of a zombie process should also be moved to `readCmdlineFile` and the function renamed. Please, let me know what you think about it.

This closes issue #930.