### PR TITLE
update man page text about delay

### DIFF
--- a/htop.1.in
+++ b/htop.1.in
@@ -22,7 +22,9 @@ Mandatory arguments to long options are mandatory for short options too.
 .LP 
 .TP
 \fB\-d \-\-delay=DELAY\fR
-Delay between updates, in tenths of seconds
+Delay between updates, in tenths of seconds. If the delay value is
+less than 1 it is increased to 1, i.e. 1/10 second. If the delay value
+is greater than 100, it is decreased to 100, i.e. 10 seconds.
 .TP
 \fB\-C \-\-no-color \-\-no-colour\fR
 Start htop in monochrome mode


### PR DESCRIPTION
It has bothered me for quite some time that running `htop -d 590` does not delay 59 seconds but something much less. I finally looked at the code today and see that the delay is clamped to `1 <= delay <= 100', i.e. a minimum of 0.1 seconds and maximum of 10.0 seconds. It's not clear to me in looking at the code history if there's some design reason for this, so I propose this change to the manual page. I'd be happy to change the code to remove this restriction and revert this proposed change to the manual page, but I think that requires a bit more discussion.