### PR TITLE
Add options to display parents and children processes in filter view

### DIFF
--- a/DisplayOptionsPanel.c
+++ b/DisplayOptionsPanel.c
@@ -84,6 +84,8 @@ DisplayOptionsPanel* DisplayOptionsPanel_new(Settings* settings, ScreenManager* 
 
    Panel_setHeader(super, "Display options");
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Tree view"), &(settings->treeView)));
+   Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Show parent processes during filter"), &(settings->showParentsInFilter)));
+   Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Show children processes during filter"), &(settings->showChildrenInFilter)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Shadow other users' processes"), &(settings->shadowOtherUsers)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Hide kernel threads"), &(settings->hideKernelThreads)));
    Panel_add(super, (Object*) CheckItem_newByRef(xStrdup("Hide userland process threads"), &(settings->hideUserlandThreads)));

--- a/Settings.c
+++ b/Settings.c
@@ -46,6 +46,8 @@ typedef struct Settings_ {
    bool countCPUsFromZero;
    bool detailedCPUTime;
    bool treeView;
+   bool showParentsInFilter;
+   bool showChildrenInFilter;
    bool showProgramPath;
    bool hideThreads;
    bool shadowOtherUsers;
@@ -196,6 +198,10 @@ static bool Settings_read(Settings* this, const char* fileName) {
          this->direction = atoi(option[1]);
       } else if (String_eq(option[0], "tree_view")) {
          this->treeView = atoi(option[1]);
+      } else if (String_eq(option[0], "show_parents_in_filter")) {
+         this->showParentsInFilter = atoi(option[1]);
+      } else if (String_eq(option[0], "show_children_in_filter")) {
+         this->showChildrenInFilter = atoi(option[1]);
       } else if (String_eq(option[0], "hide_threads")) {
          this->hideThreads = atoi(option[1]);
       } else if (String_eq(option[0], "hide_kernel_threads")) {
@@ -309,6 +315,8 @@ bool Settings_write(Settings* this) {
    fprintf(fd, "highlight_megabytes=%d\n", (int) this->highlightMegabytes);
    fprintf(fd, "highlight_threads=%d\n", (int) this->highlightThreads);
    fprintf(fd, "tree_view=%d\n", (int) this->treeView);
+   fprintf(fd, "show_parents_in_filter=%d\n", (int) this->showParentsInFilter);
+   fprintf(fd, "show_children_in_filter=%d\n", (int) this->showChildrenInFilter);
    fprintf(fd, "header_margin=%d\n", (int) this->headerMargin);
    fprintf(fd, "detailed_cpu_time=%d\n", (int) this->detailedCPUTime);
    fprintf(fd, "cpu_count_from_zero=%d\n", (int) this->countCPUsFromZero);
@@ -336,6 +344,8 @@ Settings* Settings_new(int cpuCount) {
    this->hideKernelThreads = false;
    this->hideUserlandThreads = false;
    this->treeView = false;
+   this->showParentsInFilter = false;
+   this->showChildrenInFilter = false;
    this->highlightBaseName = false;
    this->highlightMegabytes = false;
    this->detailedCPUTime = false;

--- a/Settings.h
+++ b/Settings.h
@@ -37,6 +37,8 @@ typedef struct Settings_ {
    bool countCPUsFromZero;
    bool detailedCPUTime;
    bool treeView;
+   bool showParentsInFilter;
+   bool showChildrenInFilter;
    bool showProgramPath;
    bool hideThreads;
    bool shadowOtherUsers;


### PR DESCRIPTION
Add two new display options for filtering mode:

- Display all parent processes up to root process.

- Display all children processes for filtered process.

I imagine a regular use case (at least it's my main use case) where user has multiple commands being executed in different screen/tmux windows which user would like to monitor without the distractions from kernel tasks and other processes. 

Example how it looks like with the two options enabled.

```
CPU% MEM%   TIME+  Command                                                                                                                                             
 0.0  0.1  0:26.54 /sbin/init splash
 0.0  0.1  0:00.23 ├─ /lib/systemd/systemd --user
 0.0  0.0  0:00.94 │  ├─ tmux                                                                                                                                          
 0.0  0.1  0:00.09 │  │  ├─ -bash
 0.0  0.0  0:00.00 │  │  │  └─ -bash
 0.0  0.0  0:00.00 │  │  │     └─ tail -f tmp.sh
 0.0  0.1  0:00.07 │  │  ├─ -bash
 0.0  0.1  0:00.02 │  │  │  └─ vi edit.txt
 0.0  0.1  0:00.14 │  │  └─ -bash
 4.6  0.1  0:02.60 │  │     └─ ./install_dir/bin/htop 
 1.3  0.5  1:02.26 │  ├─ /usr/lib/gnome-terminal/gnome-terminal-server
 0.0  0.1  0:01.06 │  │  └─ bash
 0.0  0.0  0:00.00 │  │     └─ tmux



F1Help  F2Setup F3SearchF4FilterF5SortedF6CollapF7Nice -F8Nice +F9Kill  F10Quit                                                                                                                                    
```