### PR TITLE
Add s390x support for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,6 @@ arch:
   - amd64
   - s390x
 
-branches:
-  only:
-  - s390x-travis
-
 before_script:
   if [[ $(uname -m) == 's390x' ]]; then
       sudo apt-get update && sudo apt-get install -y libncursesw5-dev ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,17 @@ os:
   - linux
   - osx
 
+arch:
+  - amd64
+  - s390x
+
+branches:
+  only:
+  - s390x-travis
+
+before_script:
+  if [[ $(uname -m) == 's390x' ]]; then
+      sudo apt-get update && sudo apt-get install -y libncursesw5-dev ;
+  fi
+  
 script: ./autogen.sh && ./configure && make


### PR DESCRIPTION
As Travis CI [officially supports](https://blog.travis-ci.com/2019-11-12-multi-cpu-architecture-ibm-power-ibm-z) s390x builds, adding support for same.