### PR TITLE
Fix gcc10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ os:
   - linux
   - osx
 
-script: ./autogen.sh && ./configure && make
+script: ./autogen.sh && ./configure CFLAGS="-O2 -fno-common" && make

--- a/CRT.h
+++ b/CRT.h
@@ -140,7 +140,7 @@ extern const char **CRT_treeStr;
 
 extern int CRT_delay;
 
-int* CRT_colors;
+extern int* CRT_colors;
 
 extern int CRT_colorSchemes[LAST_COLORSCHEME][LAST_COLORELEMENT];
 
@@ -150,13 +150,13 @@ extern int CRT_scrollHAmount;
 
 extern int CRT_scrollWheelVAmount;
 
-char* CRT_termType;
+extern char* CRT_termType;
 
 // TODO move color scheme to Settings, perhaps?
 
 extern int CRT_colorScheme;
 
-void *backtraceArray[128];
+extern void *backtraceArray[128];
 
 #if HAVE_SETUID_ENABLED
 

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -144,7 +144,7 @@ typedef struct LinuxProcess_ {
 #endif
 
 
-long long btime; /* semi-global */
+extern long long btime; /* semi-global */
 
 extern ProcessFieldData Process_fields[];
 


### PR DESCRIPTION
Hi @hishamhm 
GCC 10 switches from `-fcommon` to `-fno-common` by default (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85678), and htop currently fails when building against `-fno-common`.

I've enabled `-fno-common` in Travis to emulate GCC 10's behaviour, to catch any future bugs like this.