### PR TITLE
htop: fix build failure against gcc-10

### DIFF
--- a/CRT.h
+++ b/CRT.h
@@ -140,7 +140,7 @@ extern const char **CRT_treeStr;
 
 extern int CRT_delay;
 
-int* CRT_colors;
+extern int* CRT_colors;
 
 extern int CRT_colorSchemes[LAST_COLORSCHEME][LAST_COLORELEMENT];
 
@@ -150,13 +150,13 @@ extern int CRT_scrollHAmount;
 
 extern int CRT_scrollWheelVAmount;
 
-char* CRT_termType;
+extern char* CRT_termType;
 
 // TODO move color scheme to Settings, perhaps?
 
 extern int CRT_colorScheme;
 
-void *backtraceArray[128];
+extern void *backtraceArray[128];
 
 #if HAVE_SETUID_ENABLED
 

--- a/linux/LinuxProcess.h
+++ b/linux/LinuxProcess.h
@@ -144,7 +144,7 @@ typedef struct LinuxProcess_ {
 #endif
 
 
-long long btime; /* semi-global */
+extern long long btime; /* semi-global */
 
 extern ProcessFieldData Process_fields[];
 


### PR DESCRIPTION
On gcc-10 (and gcc-9 -fno-common) build fails as:

```
gcc -pedantic ... -o htop ...
ld: ClockMeter.o:/home/slyfox/dev/git/htop/CRT.h:159:
  multiple definition of `backtraceArray'; CheckItem.o:htop/CRT.h:159: first defined here
ld: ClockMeter.o:/home/slyfox/dev/git/htop/CRT.h:153:
  multiple definition of `CRT_termType'; CheckItem.o:htop/CRT.h:153: first defined here
```

gcc-10 will change the default from -fcommon to fno-common:
https://gcc.gnu.org/PR85678.

The error also happens if CFLAGS=-fno-common passed explicitly.

Reported-by: Toralf Förster
Bug: https://bugs.gentoo.org/706358