### PR TITLE
Introduce 4-column CPU Meter option

### DIFF
--- a/CPUMeter.c
+++ b/CPUMeter.c
@@ -152,7 +152,9 @@ static void AllCPUsMeter_init(Meter* this) {
    if (this->mode == 0)
       this->mode = BAR_METERMODE;
    int h = Meter_modes[this->mode]->h;
-   if (strchr(Meter_name(this), '2'))
+   if (strchr(Meter_name(this), '4'))
+      this->h = h * ((count+1) / 4);
+   else if (strchr(Meter_name(this), '2'))
       this->h = h * ((count+1) / 2);
    else
       this->h = h * count;
@@ -175,10 +177,49 @@ static void AllCPUsMeter_updateMode(Meter* this, int mode) {
    for (int i = 0; i < count; i++) {
       Meter_setMode(meters[i], mode);
    }
-   if (strchr(Meter_name(this), '2'))
+   if (strchr(Meter_name(this), '4'))
+      this->h = h * ((count+1) / 4);
+   else if (strchr(Meter_name(this), '2'))
       this->h = h * ((count+1) / 2);
    else
       this->h = h * count;
+}
+
+static void QuadColCPUsMeter_draw(Meter* this, int x, int y, int w) {
+   Meter** meters = (Meter**) this->drawData;
+   int start, count;
+   int pad = this->pl->settings->headerMargin ? 2 : 0;
+   AllCPUsMeter_getRange(this, &start, &count);
+   int height = (count+1)/4;
+   int startY = y;
+   for (int i = 0; i < height; i++) {
+      meters[i]->draw(meters[i], x, y, (w-pad)/4);
+      y += meters[i]->h;
+   }
+   int startI = height;
+   int endI = MIN(count, 2*height);
+   int X = (w-1)/4+1+(pad/2);
+   y = startY;
+   for (int i = startI; i < endI; i++) {
+      meters[i]->draw(meters[i], x+X, y, (w-pad)/4);
+      y += meters[i]->h;
+   }
+   startI = 2*height;
+   endI = MIN(count, 3*height);
+   X = (w-1)/2+1+(pad/2);
+   y = startY;
+   for (int i = startI; i < endI; i++) {
+      meters[i]->draw(meters[i], x+X, y, (w-pad)/4);
+      y += meters[i]->h;
+   }
+   startI = 3*height;
+   endI = count;
+   X = (w-1)/4*3+1+(pad/2);
+   y = startY;
+   for (int i = startI; i < endI; i++) {
+      meters[i]->draw(meters[i], x+X, y, (w-pad)/4);
+      y += meters[i]->h;
+   }
 }
 
 static void DualColCPUsMeter_draw(Meter* this, int x, int y, int w) {
@@ -264,6 +305,25 @@ MeterClass AllCPUs2Meter_class = {
    .done = AllCPUsMeter_done
 };
 
+MeterClass AllCPUs4Meter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete,
+      .display = CPUMeter_display
+   },
+   .defaultMode = CUSTOM_METERMODE,
+   .total = 100.0,
+   .attributes = CPUMeter_attributes,
+   .name = "AllCPUs4",
+   .uiName = "CPUs (1&2&3&4/4)",
+   .description = "CPUs (1&2&3&4/4): all CPUs in 4 shorter columns",
+   .caption = "CPU",
+   .draw = QuadColCPUsMeter_draw,
+   .init = AllCPUsMeter_init,
+   .updateMode = AllCPUsMeter_updateMode,
+   .done = AllCPUsMeter_done
+};
+
 MeterClass LeftCPUsMeter_class = {
    .super = {
       .extends = Class(Meter),
@@ -340,3 +400,40 @@ MeterClass RightCPUs2Meter_class = {
    .done = AllCPUsMeter_done
 };
 
+MeterClass LeftCPUs4Meter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete,
+      .display = CPUMeter_display
+   },
+   .defaultMode = CUSTOM_METERMODE,
+   .total = 100.0,
+   .attributes = CPUMeter_attributes,
+   .name = "LeftCPUs4",
+   .uiName = "CPUs (1&2&3&4/8)",
+   .description = "CPUs (1&2&3&4/8): first half in 4 shorter columns",
+   .caption = "CPU",
+   .draw = QuadColCPUsMeter_draw,
+   .init = AllCPUsMeter_init,
+   .updateMode = AllCPUsMeter_updateMode,
+   .done = AllCPUsMeter_done
+};
+
+MeterClass RightCPUs4Meter_class = {
+   .super = {
+      .extends = Class(Meter),
+      .delete = Meter_delete,
+      .display = CPUMeter_display
+   },
+   .defaultMode = CUSTOM_METERMODE,
+   .total = 100.0,
+   .attributes = CPUMeter_attributes,
+   .name = "RightCPUs4",
+   .uiName = "CPUs (5&6&7&8/8)",
+   .description = "CPUs (5&6&7&8/8): second half in 4 shorter columns",
+   .caption = "CPU",
+   .draw = QuadColCPUsMeter_draw,
+   .init = AllCPUsMeter_init,
+   .updateMode = AllCPUsMeter_updateMode,
+   .done = AllCPUsMeter_done
+};

--- a/CPUMeter.h
+++ b/CPUMeter.h
@@ -39,6 +39,8 @@ extern MeterClass AllCPUsMeter_class;
 
 extern MeterClass AllCPUs2Meter_class;
 
+extern MeterClass AllCPUs4Meter_class;
+
 extern MeterClass LeftCPUsMeter_class;
 
 extern MeterClass RightCPUsMeter_class;
@@ -47,5 +49,8 @@ extern MeterClass LeftCPUs2Meter_class;
 
 extern MeterClass RightCPUs2Meter_class;
 
+extern MeterClass LeftCPUs4Meter_class;
+
+extern MeterClass RightCPUs4Meter_class;
 
 #endif

--- a/Settings.c
+++ b/Settings.c
@@ -116,7 +116,12 @@ static void Settings_defaultMeters(Settings* this) {
    }
    
    int r = 0;
-   if (this->cpuCount > 8) {
+   if (this->cpuCount > 32) {
+      this->columns[0].names[0] = xStrdup("LeftCPUs4");
+      this->columns[0].modes[0] = BAR_METERMODE;
+      this->columns[1].names[r] = xStrdup("RightCPUs4");
+      this->columns[1].modes[r++] = BAR_METERMODE;
+   } else if (this->cpuCount > 8) {
       this->columns[0].names[0] = xStrdup("LeftCPUs2");
       this->columns[0].modes[0] = BAR_METERMODE;
       this->columns[1].names[r] = xStrdup("RightCPUs2");

--- a/linux/Platform.c
+++ b/linux/Platform.c
@@ -121,10 +121,13 @@ MeterClass* Platform_meterTypes[] = {
    &HostnameMeter_class,
    &AllCPUsMeter_class,
    &AllCPUs2Meter_class,
+   &AllCPUs4Meter_class,
    &LeftCPUsMeter_class,
    &RightCPUsMeter_class,
    &LeftCPUs2Meter_class,
    &RightCPUs2Meter_class,
+   &LeftCPUs4Meter_class,
+   &RightCPUs4Meter_class,
    &BlankMeter_class,
    NULL
 };


### PR DESCRIPTION
Enable this option on Linux, when CPU count > 32 by default.