### PR TITLE
Add option to collapse trees deeper than specified level

### DIFF
--- a/Action.c
+++ b/Action.c
@@ -152,6 +152,7 @@ static bool expandCollapse(Panel* panel) {
    Process* p = (Process*) Panel_getSelected(panel);
    if (!p) return false;
    p->showChildren = !p->showChildren;
+   p->settings->collapseLevel = -1;
    return true;
 }
 

--- a/ProcessList.c
+++ b/ProcessList.c
@@ -183,6 +183,17 @@ static void ProcessList_buildTree(ProcessList* this, pid_t pid, int level, int i
       Process* process = (Process*) (Vector_get(children, i));
       if (!show)
          process->show = false;
+      if (this->settings->collapseLevel != -1 && level + 2 > this->settings->collapseLevel) {
+         bool hasChild = false;
+         for (int i = Vector_size(this->processes) - 1; i >= 0; i--) {
+            Process* gc = (Process*) (Vector_get(this->processes, i));
+            if (gc->show && Process_isChildOf(gc, process->pid)) {
+               hasChild = true;
+               break;
+            }
+         }
+         process->showChildren = !hasChild;
+      }
       int s = this->processes2->items;
       if (direction == 1)
          Vector_add(this->processes2, process);
@@ -252,6 +263,7 @@ void ProcessList_sort(ProcessList* this) {
                process = (Process*)(Vector_take(this->processes, i));
                process->indent = 0;
                Vector_add(this->processes2, process);
+               process->showChildren = process->settings->collapseLevel != 0 && process->showChildren;
                ProcessList_buildTree(this, process->pid, 0, 0, direction, process->showChildren);
                break;
             }

--- a/Settings.c
+++ b/Settings.c
@@ -38,6 +38,7 @@ typedef struct Settings_ {
    int flags;
    int colorScheme;
    int delay;
+   int collapseLevel;
 
    int cpuCount;
    int direction;
@@ -196,6 +197,8 @@ static bool Settings_read(Settings* this, const char* fileName) {
          this->direction = atoi(option[1]);
       } else if (String_eq(option[0], "tree_view")) {
          this->treeView = atoi(option[1]);
+      } else if (String_eq(option[0], "collapse_level")) {
+         this->collapseLevel = atoi(option[1]);
       } else if (String_eq(option[0], "hide_threads")) {
          this->hideThreads = atoi(option[1]);
       } else if (String_eq(option[0], "hide_kernel_threads")) {
@@ -309,6 +312,7 @@ bool Settings_write(Settings* this) {
    fprintf(fd, "highlight_megabytes=%d\n", (int) this->highlightMegabytes);
    fprintf(fd, "highlight_threads=%d\n", (int) this->highlightThreads);
    fprintf(fd, "tree_view=%d\n", (int) this->treeView);
+   fprintf(fd, "expand_level=%d\n", (int) this->collapseLevel);
    fprintf(fd, "header_margin=%d\n", (int) this->headerMargin);
    fprintf(fd, "detailed_cpu_time=%d\n", (int) this->detailedCPUTime);
    fprintf(fd, "cpu_count_from_zero=%d\n", (int) this->countCPUsFromZero);
@@ -336,6 +340,7 @@ Settings* Settings_new(int cpuCount) {
    this->hideKernelThreads = false;
    this->hideUserlandThreads = false;
    this->treeView = false;
+   this->collapseLevel = -1;
    this->highlightBaseName = false;
    this->highlightMegabytes = false;
    this->detailedCPUTime = false;

--- a/Settings.c
+++ b/Settings.c
@@ -312,7 +312,7 @@ bool Settings_write(Settings* this) {
    fprintf(fd, "highlight_megabytes=%d\n", (int) this->highlightMegabytes);
    fprintf(fd, "highlight_threads=%d\n", (int) this->highlightThreads);
    fprintf(fd, "tree_view=%d\n", (int) this->treeView);
-   fprintf(fd, "expand_level=%d\n", (int) this->collapseLevel);
+   fprintf(fd, "collapse_level=%d\n", (int) this->collapseLevel);
    fprintf(fd, "header_margin=%d\n", (int) this->headerMargin);
    fprintf(fd, "detailed_cpu_time=%d\n", (int) this->detailedCPUTime);
    fprintf(fd, "cpu_count_from_zero=%d\n", (int) this->countCPUsFromZero);

--- a/Settings.h
+++ b/Settings.h
@@ -29,6 +29,7 @@ typedef struct Settings_ {
    int flags;
    int colorScheme;
    int delay;
+   int collapseLevel;
 
    int cpuCount;
    int direction;


### PR DESCRIPTION
This is just a proposal with code. Please feel free to close.

The option collapses trees that are deeper than specified level.

The option character is '-l' (small L) from Level. It's collapseLevel in code.
Checking whether a process has any child or not is because to set better value to "Process.showChildren". It improves `+/-` signs before process name.
The collapseLevel will be cleared when user expands or collapses any tree.

I don't know this is reasonable approach or not, but I think it's practical one. Of course, htop is an important tool and should be implemented carefully.
I hope it will be useful stuff as one of the experiments.

Thank you.
<br>

### Examples:

```
htop -t -l 0
```
<img src="https://user-images.githubusercontent.com/3457662/82830816-bf2e2200-9ef1-11ea-9ceb-c99eae6a24c5.png">

```
htop -t -l 1
```
<img src="https://user-images.githubusercontent.com/3457662/82830815-be958b80-9ef1-11ea-99af-8f569552f77d.png">


↑ Some of signs are `"+"` those have any child processes, other signs are `"-"`.

<br>
<br>

```
htop -t -l 2
```
<img src="https://user-images.githubusercontent.com/3457662/82830818-bfc6b880-9ef1-11ea-9dd2-2709b0b802d1.png">

```
htop -t   # without -l option
```
<img src="https://user-images.githubusercontent.com/3457662/82831090-6f038f80-9ef2-11ea-8837-361ca22107de.png">

