### PR TITLE
Fix use of '-rdynamic'

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -53,7 +53,7 @@ linux_platform_headers = \
 all_platform_headers += $(linux_platform_headers)
 
 if HTOP_LINUX
-AM_CFLAGS += -rdynamic
+AM_LDFLAGS += -rdynamic
 myhtopplatsources = linux/Platform.c linux/IOPriorityPanel.c linux/IOPriority.c \
 linux/LinuxProcess.c linux/LinuxProcessList.c linux/LinuxCRT.c linux/Battery.c
 


### PR DESCRIPTION
The option should be informed to the linker.