### PR TITLE
Remove INSTALL link in README.

### DIFF
--- a/README
+++ b/README
@@ -38,7 +38,6 @@ Compilation instructions
 ------------------------
 
 This program is distributed as a standard autotools-based package.
-See the [INSTALL](/INSTALL) file for detailed instructions.
 
 When compiling from a [release tarball](https://hisham.hm/htop/releases/), run:
 


### PR DESCRIPTION
Link is broken and no similar file exists.